### PR TITLE
Fixes Brickadia login issues

### DIFF
--- a/src/brickadia/server.js
+++ b/src/brickadia/server.js
@@ -86,9 +86,9 @@ class BrickadiaServer extends EventEmitter {
       '--',
       ...launchArgs,
       '-NotInstalled', '-log',
-      this.path && `-UserDir="${this.path}"`,
-      email && `-User="${email}"`, // remove email argument if not provided
-      password && `-Password="${password}"`, // remove password argument if not provided
+      this.path ? `-UserDir="${this.path}"` : null,
+      email ? `-User="${email}"` : null, // remove email argument if not provided
+      password ? `-Password="${password}"` : null, // remove password argument if not provided
       `-port="${this.config.server.port}"`,
     ].filter(v => v)); // remove unused arguments
 

--- a/tools/brickadia.sh
+++ b/tools/brickadia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # runs local brickadia
 BIN_DIR=/home/$USER/.config/omegga/launcher/brickadia-launcher
 export LD_LIBRARY_PATH=$BIN_DIR:$LD_LIBRARY_PATH

--- a/tools/brickadia.sh
+++ b/tools/brickadia.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # runs local brickadia
 BIN_DIR=/home/$USER/.config/omegga/launcher/brickadia-launcher
 export LD_LIBRARY_PATH=$BIN_DIR:$LD_LIBRARY_PATH


### PR DESCRIPTION
I had trouble with actually getting a) the brickadia.sh script to run and b) authenticating the server. It seems that incorrect ternary logic (or maybe correct, not sure) in the brickadia server.js caused me unable to authenticate with the server. I also corrected the brickadia.sh script to use `#!/bin/bash` instead of `#!/bin/sh` - it's caused quite a few issues for me in the past so correcting it will make sure the script can run correctly.