### PR TITLE
Disrequire all imported files from unsafe plugins when unloading

### DIFF
--- a/src/omegga/plugin/plugin_node_unsafe.js
+++ b/src/omegga/plugin/plugin_node_unsafe.js
@@ -51,7 +51,7 @@ class NodePlugin extends Plugin {
   async load() {
     const stopPlugin = reason => {
       Omegga.error('error launching node plugin', this.getName(), ':', reason);
-      try{disrequire(this.pluginFile);}catch(e){Omegga.error('error unloading node plugin (2)', this.getName(), e);}
+      try{this.disrequireAll();}catch(e){Omegga.error('error unloading node plugin (2)', this.getName(), e);}
       this.emitStatus();
       return false;
     };
@@ -117,7 +117,7 @@ class NodePlugin extends Plugin {
         await this.loadedPlugin.stop();
 
       // unload the plugin
-      disrequire(this.pluginFile);
+      this.disrequireAll();
       this.loadedPlugin = undefined;
       this.emitStatus();
       this.commands = [];
@@ -127,6 +127,14 @@ class NodePlugin extends Plugin {
       this.emitStatus();
       return false;
     }
+  }
+
+  // disrequire all that match plugin path in require.cache
+  disrequireAll() {
+    // get all files in plugin directory from require cache
+    const requiredFiles = Object.keys(require.cache).filter(requiredFile => requiredFile.includes(this.path));
+    // disrequire all the files
+    requiredFiles.forEach(file => disrequire(file));
   }
 }
 


### PR DESCRIPTION
Only omegga.main.js is getting disrequired, when a plugin is reloaded it is still using the cached files