### PR TITLE
Add position-related methods to the RPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ Register custom `/commands` by returning `{registeredCommands: ['foo', 'bar']}` 
 | `broadcast` | line (string) | Broadcasts a message to the server|
 | `whisper` | {target: string, line: string} | (a5 only) Sends a message to a specific client |
 | `getPlayers` | _none_ | Gets online players |
+| `getPlayerPosition` | target (string) | Gets the position of the player with the given name/ID |
+| `getAllPlayerPositions` | _none_ | Gets an array of objects with fields `pos` and `player`, representing the position and player object of each player in the server |
 | `getRoleSetup` | _none_ | Gets server roles |
 | `getBanList` | _none_ | Gets list of bans |
 | `getSaves` | _none_ | Gets saves in the saves directory |

--- a/src/omegga/plugin/plugin_jsonrpc_stdio.js
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.js
@@ -324,7 +324,7 @@ class RpcPlugin extends Plugin {
     rpc.addMethod('broadcast', line => this.omegga.broadcast(line));
     rpc.addMethod('whisper', ({target, line}) => this.omegga.whisper(target, line));
     rpc.addMethod('getPlayers', () => this.omegga.getPlayers());
-    rpc.addMethod('getPlayerPosition', (name) => this.omegga.getPlayer(name).getPosition());
+    rpc.addMethod('getPlayerPosition', (name) => this.omegga.getPlayer(name)?.getPosition());
     rpc.addMethod('getAllPlayerPositions', () => this.omegga.getAllPlayerPositions());
     rpc.addMethod('getRoleSetup', () => this.omegga.getRoleSetup());
     rpc.addMethod('getBanList', () => this.omegga.getBanList());

--- a/src/omegga/plugin/plugin_jsonrpc_stdio.js
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.js
@@ -324,6 +324,8 @@ class RpcPlugin extends Plugin {
     rpc.addMethod('broadcast', line => this.omegga.broadcast(line));
     rpc.addMethod('whisper', ({target, line}) => this.omegga.whisper(target, line));
     rpc.addMethod('getPlayers', () => this.omegga.getPlayers());
+    rpc.addMethod('getPlayerPosition', (name) => this.omegga.getPlayer(name).getPosition());
+    rpc.addMethod('getAllPlayerPositions', () => this.omegga.getAllPlayerPositions());
     rpc.addMethod('getRoleSetup', () => this.omegga.getRoleSetup());
     rpc.addMethod('getBanList', () => this.omegga.getBanList());
     rpc.addMethod('getSaves', () => this.omegga.getBanList());


### PR DESCRIPTION
This PR adds `getPlayerPosition` and `getAllPlayerPositions` to the arsenal of methods supported by the RPC server. Both methods return the same objects as they do in JS.

* In the case of `getPlayerPosition`, an array of three numbers are returned.
* For `getAllPlayerPositions`, it returns an array of objects `{pos: [number, number, number], player: {name: string, id: string, state: string, controller: string}}`.