### PR TITLE
Add unload/reload to RPC methods

### DIFF
--- a/src/omegga/plugin/plugin_jsonrpc_stdio.js
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.js
@@ -316,8 +316,6 @@ class RpcPlugin extends Plugin {
     rpc.addMethod('store.count', () => this.storage.count());
     rpc.addMethod('store.keys', () => this.storage.keys());
 
-    rpc.addMethod('store.keys', () => this.storage.keys());
-
     // server can run console commands
     rpc.addMethod('exec', line => this.omegga.writeln(line));
     rpc.addMethod('writeln', line => this.omegga.writeln(line));
@@ -341,6 +339,11 @@ class RpcPlugin extends Plugin {
       this.omegga.loadSaveData(data, {offX, offY, offZ, quiet}));
     rpc.addMethod('changeMap', (map) =>
       this.omegga.changeMap(map));
+    rpc.addMethod('unload', () => this.unload());
+    rpc.addMethod('reload', async () => {
+      await this.unload();
+      await this.load();
+    });
   }
 
   // emit a message to the plugin via the jsonrpc client and expect a response


### PR DESCRIPTION
This PR adds `unload` and `reload` to RPC plugins. Since many RPC plugins might use compiled languages, it is useful to allow them to build and reload themselves automatically.

One thing I'd like to note is that this functionality is not made available to safe node plugins (at least as far as I know). Would it be worth finding a good way to integrate this behavior into safe node plugins? Could we use `access.json` to allow certain safe node plugins to reload _any_ other plugin, or interact with the `pluginLoader` in full?