### PR TITLE
feat(rpc): add player related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,6 @@ Register custom `/commands` by returning `{registeredCommands: ['foo', 'bar']}` 
 | `broadcast` | line (string) | Broadcasts a message to the server|
 | `whisper` | {target: string, line: string} | (a5 only) Sends a message to a specific client |
 | `getPlayers` | _none_ | Gets online players |
-| `getPlayerPosition` | target (string) | Gets the position of the player with the given name/ID |
 | `getAllPlayerPositions` | _none_ | Gets an array of objects with fields `pos` and `player`, representing the position and player object of each player in the server |
 | `getRoleSetup` | _none_ | Gets server roles |
 | `getBanList` | _none_ | Gets list of bans |
@@ -645,6 +644,14 @@ Register custom `/commands` by returning `{registeredCommands: ['foo', 'bar']}` 
 | `readSaveData` | name (string) | Parses save into a brs-js save object, returns the object |
 | `loadSaveData` | {data: object, offX=0 (Number), offY=0 (Number), offY=0 (Number), quiet: bool (a5 only)} | Loads brs-js save data object to the server |
 | `changeMap` | map (string) | Change map to specified map name, returns if succeeded |
+| `player.getPermissions` | target (string) | Gets the target's permissions |
+| `player.getNameColor` | target (string) | Gets the target's name color |
+| `player.getPosition` | target (string) | Gets the target's position |
+| `player.getGhostBrick` | target (string) | Gets info on the target's ghost brick |
+| `player.getPaint` | target (string) | Gets info on the target's current paint selection |
+| `player.getTemplateBounds` | target (string) | Gets the target's template/selection bounds |
+| `player.getTemplateBoundsData` | target (string) | Gets the target's template/selection as brs-js save data |
+| `player.loadDataAtGhostBrick` | {target: string, data: object, rotate=true (bool), offX=0 (number), offY=0 (number), offZ=0 (number), quiet=false (bool)} | Loads brs-js save data at the target's template/selection bounds |
 
 ### Plugin Methods (You implement these)
 

--- a/src/omegga/plugin/plugin_jsonrpc_stdio.js
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.js
@@ -12,7 +12,7 @@ const { bootstrap } = require('./plugin_node_safe/proxyOmegga.js');
 
 // TODO: check if version is compatible (v1 -> v2) from file
 // TODO: write jsonrpc wrappers in a few languages, implement a few simple plugins
-// TODO: languages: [ python, rust, go ]
+// TODO: languages: [ python, go ]
 
 const MAIN_FILE = 'omegga_plugin';
 const DOC_FILE = 'doc.json';
@@ -322,7 +322,7 @@ class RpcPlugin extends Plugin {
     rpc.addMethod('broadcast', line => this.omegga.broadcast(line));
     rpc.addMethod('whisper', ({target, line}) => this.omegga.whisper(target, line));
     rpc.addMethod('getPlayers', () => this.omegga.getPlayers());
-    rpc.addMethod('getPlayerPosition', (name) => this.omegga.getPlayer(name)?.getPosition());
+    rpc.addMethod('getPlayerPosition', (name) => this.omegga.getPlayer(name)?.getPosition()); // included for compatibility
     rpc.addMethod('getAllPlayerPositions', () => this.omegga.getAllPlayerPositions());
     rpc.addMethod('getRoleSetup', () => this.omegga.getRoleSetup());
     rpc.addMethod('getBanList', () => this.omegga.getBanList());
@@ -344,6 +344,18 @@ class RpcPlugin extends Plugin {
       await this.unload();
       await this.load();
     });
+
+    // player related operations
+    const addPlayerMethod = (name) => rpc.addMethod(`player.${name}`, (player) => this.omegga.getPlayer(player)?.[name]());
+    addPlayerMethod('getPermissions');
+    addPlayerMethod('getNameColor');
+    addPlayerMethod('getPosition');
+    addPlayerMethod('getGhostBrick');
+    addPlayerMethod('getPaint');
+    addPlayerMethod('getTemplateBounds');
+    addPlayerMethod('getTemplateBoundsData');
+    rpc.addMethod('player.loadDataAtGhostBrick', ({target, data, rotate=true, offX=0, offY=0, offZ=0, quiet=false}) =>
+      this.omegga.getPlayer(target)?.loadDataAtGhostBrick(data, {rotate, offX, offY, offZ, quiet}));
   }
 
   // emit a message to the plugin via the jsonrpc client and expect a response


### PR DESCRIPTION
This PR adds and documents the following RPC methods:

* `player.getPermissions`
* `player.getNameColor`
* `player.getPosition`
* `player.getGhostBrick`
* `player.getPaint`
* `player.getTemplateBounds`
* `player.getTemplateBoundsData`
* `player.loadDataAtGhostBrick`

Moreover, the RPC method `getPlayerPosition` has been removed from documentation, as it has been obsoleted by `player.getPosition`. It is still registered by the RPC server for compatibility however.