### PR TITLE
feat(plugin): emitConfig field for plugin.json to emit the config on plugin load

### DIFF
--- a/src/omegga/plugin/plugin_node_safe.js
+++ b/src/omegga/plugin/plugin_node_safe.js
@@ -19,6 +19,7 @@ const MAIN_FILE = 'omegga.plugin.js';
 // Documentation file (contains name, description, author, command helptext)
 const DOC_FILE = 'doc.json';
 const ACCESS_FILE = 'access.json';
+const PLUGIN_FILE = 'plugin.json';
 
 class NodeVmPlugin extends Plugin {
   #worker = undefined;
@@ -45,6 +46,7 @@ class NodeVmPlugin extends Plugin {
 
     // TODO: validate documentation
     this.documentation = Plugin.readJSON(path.join(pluginPath, DOC_FILE));
+    this.pluginConfig = Plugin.readJSON(path.join(pluginPath, PLUGIN_FILE));
 
     // access list is a list of builtin requires
     // can be ['*'] for everything
@@ -161,6 +163,9 @@ class NodeVmPlugin extends Plugin {
 
     try {
       const config = await this.storage.getConfig();
+      if (this.pluginConfig?.emitConfig) {
+        await fs.promises.writeFile(path.join(this.path, this.pluginConfig.emitConfig), JSON.stringify(config));
+      }
       this.createWorker();
 
       // tell the worker its name :)

--- a/src/omegga/plugin/plugin_node_unsafe.js
+++ b/src/omegga/plugin/plugin_node_unsafe.js
@@ -14,6 +14,7 @@ const MAIN_FILE = 'omegga.main.js';
 
 // Documentation file (contains name, description, author, command helptext)
 const DOC_FILE = 'doc.json';
+const PLUGIN_FILE = 'plugin.json';
 
 class NodePlugin extends Plugin {
   // every node plugin requires the main file and a doc file
@@ -30,6 +31,7 @@ class NodePlugin extends Plugin {
     super(pluginPath, omegga);
     // TODO: validate documentation
     this.documentation = Plugin.readJSON(path.join(pluginPath, DOC_FILE));
+    this.pluginConfig = Plugin.readJSON(path.join(pluginPath, PLUGIN_FILE));
     this.pluginFile = path.join(pluginPath, MAIN_FILE);
 
     // list of registered comands
@@ -59,6 +61,9 @@ class NodePlugin extends Plugin {
 
     try {
       const config = await this.storage.getConfig();
+      if (this.pluginConfig?.emitConfig) {
+        await fs.promises.writeFile(path.join(this.path, this.pluginConfig.emitConfig), JSON.stringify(config));
+      }
 
       // require the plugin itself
       const Plugin = require(this.pluginFile);


### PR DESCRIPTION
This PR adds the optional `emitConfig` field to `plugin.json` format. When a path to a file is specified, Omegga will write out the plugin's config object (normally passed thru the constructor of safe node plugins and thru the `init` request for RPC plugins) to that path. This is useful for RPC plugins that wish to deserialize config at startup rather than wait for the `init` request.