### PR TITLE
Add `minigamejoin` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ Register custom `/commands` by returning `{registeredCommands: ['foo', 'bar']}` 
 | `event:NAME`         | [&gt;player from click&lt;, ...args]                                                                                             | Runs when an interact component has `event:NAME: arg1,arg2,arg\,3,                                                                                                                   |          |
 | `mapchange`          | \[{map}\]                                                                                                                        | Runs when the map changes                                                                                                                                                            |          |
 | `autorestart`        | [autorestart config]                                                                                                             | Runs server has an autorestart scheduled                                                                                                                                             |          |
+| `minigamejoin`       | {player: {name, id}; minigameName: string}                                                                                       | Runs when a player joins a minigame. Note that minigameName is not unique between minigames. minigameName will be null if player leaves all minigames. This will run before `join`   |          |
 
 ### Folder Structure
 

--- a/src/omegga/matchers/index.ts
+++ b/src/omegga/matchers/index.ts
@@ -31,6 +31,9 @@ import mapChange from './mapChange';
 // interaction event
 import interact from './interact';
 
+// minigame join event
+import minigameJoin from './minigameJoin';
+
 export default [
   join,
   leave,
@@ -42,4 +45,5 @@ export default [
   init,
   mapChange,
   interact,
+  minigameJoin,
 ] as MatchGenerator<any>[];

--- a/src/omegga/matchers/minigameJoin.ts
+++ b/src/omegga/matchers/minigameJoin.ts
@@ -1,0 +1,40 @@
+import { MatchGenerator } from './types';
+
+const minigameJoin: MatchGenerator<{player: {name: string, id: string}; minigameName: string}> = omegga => {
+  // LogBrickadia: Ruleset My Minigame no saved checkpoint for player BrickadiaPlayer (00000000-0000-0000-0000-000000000000)
+  // LogBrickadia: Ruleset My Minigame loading saved checkpoint for player BrickadiaPlayer (00000000-0000-0000-0000-000000000000)
+  const minigameJoinRegExp = /^Ruleset (?<minigame>.+?) (loading|no) saved checkpoint for player (?<playerName>.+) \((?<playerId>.+)\)$/;
+
+  return {
+    // listen for commands messages
+    pattern(_line, logMatch) {
+      // line is not generic console log
+      if (!logMatch) return;
+
+      const { generator, data } = logMatch.groups;
+      // check if log is a world log
+      if (generator !== 'LogBrickadia') return;
+
+      // match the log to the map change finish pattern
+      const matchChange = data.match(minigameJoinRegExp);
+      if (matchChange) {
+        const minigame = matchChange.groups.minigame;
+        return {
+          player: {
+            name: matchChange.groups.playerName,
+            id: matchChange.groups.playerId,
+          },
+          minigameName: minigame == 'GLOBAL' ? null : minigame,
+        }
+      }
+
+      return null;
+    },
+    // when there's a match, emit the event
+    callback(result) {
+      omegga.emit('minigamejoin', result);
+    },
+  };
+};
+
+export default minigameJoin;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -433,8 +433,9 @@ export interface MockEventEmitter {
   on(
     event: 'interact',
     listener: (interaction: BrickInteraction) => void
-  ): this;
-}
+    ): this;
+  on(event: 'minigamejoin', listener: (info: {player: {name: string, id: string}; minigameName: string}) => void): this;
+  }
 
 export interface OmeggaLike
   extends OmeggaCore,


### PR DESCRIPTION
Adds a `minigamejoin` event for when a player joins a minigame or leaves all minigames. It's arguments are `{player: {name, id}; minigameName: string}` If the player leaves all minigames, `minigameName` will be null. `minigameName` is not unique, so shouldn't be relied on to find what minigame someone's in. Note that this event is called before `join`.