### PR TITLE
Change "start" to "init" in error message

### DIFF
--- a/src/omegga/plugin/plugin_jsonrpc_stdio.ts
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.ts
@@ -197,7 +197,7 @@ export default class RpcPlugin extends Plugin {
         setTimeout(() => {
           if (!frozen) return;
           Logger.errorp(
-            'I appear to be unresponsive when starting (maybe I forgot to respond to start)',
+            'I appear to be unresponsive when starting (maybe I forgot to respond to init)',
             name.brightRed.underline
           );
           this.kill();


### PR DESCRIPTION
The error occurs when the plugin doesn't respond to init, not start