### PR TITLE
Add CLI commands for modifying plugin configs

### DIFF
--- a/src/cli/plugin.ts
+++ b/src/cli/plugin.ts
@@ -1,7 +1,7 @@
 import Logger from '@/logger';
 import soft from '@/softconfig';
 import * as config from '@config';
-import Omegga from '@omegga/server';
+import { PluginLoader } from '@omegga/plugin';
 import { exec as execNonPromise } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -706,27 +706,7 @@ async function init() {
 
 function pluginLoaderFactory() {
   const workDir = getWorkDir();
-  // None of these values get used, it's just to make typechecking happy.
-  const config = {
-    server: {
-      port: 0,
-      publiclyListed: false,
-      name: '',
-      __LOCAL: false,
-      branch: '',
-    },
-    credentials: { email: '', password: '' },
-  };
-
-  // We don't need anything except the plugin loader.
-  const options = {
-    noauth: true,
-    noplugin: false,
-    noweb: true,
-    debug: false,
-  };
-  const omegga = new Omegga(workDir, config, options);
-  return omegga.pluginLoader;
+  return new PluginLoader(workDir);
 }
 
 /** Loads in a plugin and it's documentation. */

--- a/src/cli/plugin.ts
+++ b/src/cli/plugin.ts
@@ -712,14 +712,18 @@ function pluginLoaderFactory() {
 /** Loads in a plugin and it's documentation. */
 async function loadPlugin(pluginName) {
   const pluginLoader = pluginLoaderFactory();
-  await pluginLoader.scan(); // Scan for plugins and build documentation.
-  const plugin = pluginLoader.plugins.find(
-    p => p.getName().toLowerCase() === pluginName.toLowerCase()
-  );
-  if (!plugin) {
-    err('Plugin', pluginName.cyan, 'not found');
+  const foundPluginDirectory = fs
+    .readdirSync(pluginLoader.path)
+    .find(dir => dir.toLowerCase() === pluginName.toLowerCase());
+  if (!foundPluginDirectory) {
+    err(
+      `Plugin ${pluginName} not found! Make sure to use the plugin's directory name.`
+    );
     process.exit(1);
   }
+  const plugin = await pluginLoader.scanPlugin(
+    path.join(pluginLoader.path, foundPluginDirectory)
+  );
   return plugin;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -333,26 +333,12 @@ program
   });
 
 program
-  .command('list-config <pluginName>')
-  .description('Lists configs for a plugin')
-  .option('-v, --verbose', 'Print extra messages for debugging purposes')
-  .action(async pluginName => {
-    if (!config.find('.')) {
-      Logger.errorp(
-        'Not an omegga directory, run ',
-        'omegga init'.yellow,
-        'to setup one.'
-      );
-      process.exit(1);
-    }
-    const { verbose } = program.opts();
-    Logger.VERBOSE = verbose;
-    pluginUtil.listConfig(pluginName);
-  });
-
-program
-  .command('get-config <pluginName> <configName>')
-  .description('Gets a config value')
+  .command('get-config <pluginName> [configName]')
+  .description(
+    'Gets a config for a plugin. If ' +
+      'configName'.underline +
+      ' is omitted, returns all config values.'
+  )
   .option('-v, --verbose', 'Print extra messages for debugging purposes')
   .action(async (pluginName, configName) => {
     if (!config.find('.')) {
@@ -365,12 +351,23 @@ program
     }
     const { verbose } = program.opts();
     Logger.VERBOSE = verbose;
-    pluginUtil.getConfig(pluginName, configName);
+    if (!configName) {
+      pluginUtil.listConfig(pluginName);
+    } else {
+      pluginUtil.getConfig(pluginName, configName);
+    }
   });
 
 program
-  .command('set-config <pluginName> <configName> <configValue>')
-  .description('Sets a config value')
+  .command('set-config <pluginName> [configName] [configValue]')
+  .description(
+    'Sets a config for a plugin. If ' +
+      'configValue'.underline +
+      ' is omitted, the config will be reset. If ' +
+      'configName'.underline +
+      ' is omitted, the entire plugin config will be reset.'
+  )
+  .option('-y, --yes', 'Skip confirmation prompt')
   .option('-v, --verbose', 'Print extra messages for debugging purposes')
   .action(async (pluginName, configName, configValue) => {
     if (!config.find('.')) {
@@ -381,32 +378,14 @@ program
       );
       process.exit(1);
     }
-    const { verbose } = program.opts();
-    Logger.VERBOSE = verbose;
-    pluginUtil.setConfig(pluginName, configName, configValue);
-  });
-
-program
-  .command('reset-config <pluginName> [configName]')
-  .description('Resets all of configs for a plugin to the default')
-  .option('-y, --yes', 'Skip confirmation prompt')
-  .option('-v, --verbose', 'Print extra messages for debugging purposes')
-  .action(async (pluginName, configName) => {
-    if (!config.find('.')) {
-      Logger.errorp(
-        'Not an omegga directory, run ',
-        'omegga init'.yellow,
-        'to setup one.'
-      );
-      process.exit(1);
-    }
     const { verbose, yes } = program.opts();
     Logger.VERBOSE = verbose;
-
-    if (configName !== undefined) {
+    if (!configName) {
+      pluginUtil.resetAllConfigs(pluginName, yes);
+    } else if (!configValue) {
       pluginUtil.resetConfig(pluginName, configName);
     } else {
-      pluginUtil.resetAllConfigs(pluginName, yes);
+      pluginUtil.setConfig(pluginName, configName, configValue);
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -386,4 +386,28 @@ program
     pluginUtil.setConfig(pluginName, configName, configValue);
   });
 
+program
+  .command('reset-config <pluginName> [configName]')
+  .description('Resets all of configs for a plugin to the default')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('-v, --verbose', 'Print extra messages for debugging purposes')
+  .action(async (pluginName, configName) => {
+    if (!config.find('.')) {
+      Logger.errorp(
+        'Not an omegga directory, run ',
+        'omegga init'.yellow,
+        'to setup one.'
+      );
+      process.exit(1);
+    }
+    const { verbose, yes } = program.opts();
+    Logger.VERBOSE = verbose;
+
+    if (configName !== undefined) {
+      pluginUtil.resetConfig(pluginName, configName);
+    } else {
+      pluginUtil.resetAllConfigs(pluginName, yes);
+    }
+  });
+
 program.parseAsync(process.argv);

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,6 @@ const program = commander
       if (!success) {
         Logger.errorp('Start aborted - could not generate auth tokens');
         process.exit(1);
-        return;
       }
     }
 
@@ -258,7 +257,6 @@ program
     if (!require('hasbin').sync('git')) {
       Logger.errorp('git'.yellow, 'must be installed to install plugins.');
       process.exit(1);
-      return;
     }
 
     if (!config.find('.')) {
@@ -268,7 +266,6 @@ program
         'to setup one.'
       );
       process.exit(1);
-      return;
     }
     const { verbose, force } = program.opts();
     Logger.VERBOSE = verbose;
@@ -289,7 +286,6 @@ program
         'to setup one.'
       );
       process.exit(1);
-      return;
     }
     const { verbose, force } = program.opts();
     Logger.VERBOSE = verbose;
@@ -334,6 +330,60 @@ program
     Logger.VERBOSE = verbose;
 
     pluginUtil.init();
+  });
+
+program
+  .command('list-config <pluginName>')
+  .description('Lists configs for a plugin')
+  .option('-v, --verbose', 'Print extra messages for debugging purposes')
+  .action(async pluginName => {
+    if (!config.find('.')) {
+      Logger.errorp(
+        'Not an omegga directory, run ',
+        'omegga init'.yellow,
+        'to setup one.'
+      );
+      process.exit(1);
+    }
+    const { verbose } = program.opts();
+    Logger.VERBOSE = verbose;
+    pluginUtil.listConfig(pluginName);
+  });
+
+program
+  .command('get-config <pluginName> <configName>')
+  .description('Gets a config value')
+  .option('-v, --verbose', 'Print extra messages for debugging purposes')
+  .action(async (pluginName, configName) => {
+    if (!config.find('.')) {
+      Logger.errorp(
+        'Not an omegga directory, run ',
+        'omegga init'.yellow,
+        'to setup one.'
+      );
+      process.exit(1);
+    }
+    const { verbose } = program.opts();
+    Logger.VERBOSE = verbose;
+    pluginUtil.getConfig(pluginName, configName);
+  });
+
+program
+  .command('set-config <pluginName> <configName> <configValue>')
+  .description('Sets a config value')
+  .option('-v, --verbose', 'Print extra messages for debugging purposes')
+  .action(async (pluginName, configName, configValue) => {
+    if (!config.find('.')) {
+      Logger.errorp(
+        'Not an omegga directory, run ',
+        'omegga init'.yellow,
+        'to setup one.'
+      );
+      process.exit(1);
+    }
+    const { verbose } = program.opts();
+    Logger.VERBOSE = verbose;
+    pluginUtil.setConfig(pluginName, configName, configValue);
   });
 
 program.parseAsync(process.argv);

--- a/src/omegga/plugin.ts
+++ b/src/omegga/plugin.ts
@@ -397,7 +397,7 @@ export class PluginLoader {
     return ok;
   }
 
-  // find every loadable plugin
+  /** Scans plugin directory for plugins and builds their documentation. */
   async scan() {
     Logger.verbose('Scanning plugin directory');
     // plugin directory doesn't exist
@@ -422,6 +422,7 @@ export class PluginLoader {
           .filter(dir => fs.existsSync(dir) && fs.lstatSync(dir).isDirectory())
           // every plugin must be loadable through some format
           .map(async dir => {
+            Logger.verbose('Scanning plugin', dir.underline);
             // find a plugin format that can load in this plugin
             const PluginFormat = this.formats.find(f => f.canLoad(dir));
 
@@ -461,6 +462,12 @@ export class PluginLoader {
     )
       // remove plugins without formats
       .filter(p => p);
+
+    Logger.verbose('Finished scanning plugin directory');
+    Logger.verbose(
+      `Found ${this.plugins.length} plugins`,
+      this.plugins.map(p => p.getName())
+    );
 
     this.buildDocumentation();
 

--- a/src/omegga/plugin.ts
+++ b/src/omegga/plugin.ts
@@ -200,7 +200,15 @@ export class PluginStorage {
     return config.value;
   }
 
-  // initialize the plugin store
+  /** Wipes the configs for the plugin. */
+  async wipeConfig() {
+    await this.store.remove(
+      { type: 'config', plugin: this.name },
+      { multi: true }
+    );
+  }
+
+  /** Initializes the configs for the plugin into the database and sets default configs. */
   async init() {
     // get default and configured values
     const defaultConf = this.getDefaultConfig();

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -122,11 +122,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     if (!options.noplugin) {
       Logger.verbose('Creating plugin loader');
       // create the pluginloader
-      this.pluginLoader = new PluginLoader(join(this.path, PLUGIN_PATH), this);
-
-      Logger.verbose('Creating loading plugins');
-      // load all the plugin formats in
-      this.pluginLoader.loadFormats(join(__dirname, 'plugin'));
+      this.pluginLoader = new PluginLoader(this.path, this);
     }
 
     /** @type {Array<Player>}list of online players */


### PR DESCRIPTION
This PR adds the following commands:
`omegga get-config <pluginName> [configName]` - Gets a config for a plugin. If `configName` is omitted, returns all config values.
`omegga set-config <pluginName> [configName] [configValue]` - Sets a config for a plugin. If `configValue` is omitted, the config will be reset. If `configName` is omitted, the entire plugin config will be reset.

These commands allow you to alter plugin configuration using Omegga through command line.
This currently supports the config types boolean, number, string, and enum.
`<pluginName>` must be the name of the plugin directory, it does not use the name of the plugin the documentation.