### PR TITLE
Gracefully shut down server on Ctrl+C and SIGTERM

### DIFF
--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -577,6 +577,9 @@ export default class Terminal {
     );
 
     this.rl.on('line', this.handleLine.bind(this));
+    // Gracefully shut down server on Ctrl+C and SIGTERM
+    process.on('SIGINT', () => this.handleLine('/stop'));
+    process.on('SIGTERM', () => this.handleLine('/stop'));
   }
 
   async handleLine(line: string) {


### PR DESCRIPTION
This will run /stop when CTRL+C is sent or omegga is terminated. This is especially useful if running omegga in a docker container which will now gracefully shutdown on `docker stop`