### PR TITLE
Fixed Build Errors from Outdated Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "mini-css-extract-plugin": "^1.0.0",
         "sass": "^1.42.1",
         "sass-loader": "^12.1.0",
-        "ttypescript": "^1.5.13",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.6.3",
         "typescript-transform-paths": "^3.3.1",
         "url-loader": "^4.1.1",
@@ -5035,9 +5035,9 @@
       }
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -9937,9 +9937,9 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mini-css-extract-plugin": "^1.0.0",
     "sass": "^1.42.1",
     "sass-loader": "^12.1.0",
-    "ttypescript": "^1.5.13",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.6.3",
     "typescript-transform-paths": "^3.3.1",
     "url-loader": "^4.1.1",


### PR DESCRIPTION
ttypescript v1.5.13 caused a build error to occur when node version was v18.17.1 or more. 
Updating ttypescript to v1.5.15 seems to resolve this issue.