### PR TITLE
Fix web_certs.json not generating with openssl 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "lodash": "^4.17.20",
         "nedb-promises": "^5.0.1",
         "nedb-promises-session-store": "1.0.0",
-        "pem": "^1.14.4",
+        "pem": "^1.14.7",
         "prompts": "^2.4.2",
         "readline": "^1.3.0",
         "rimraf": "^3.0.2",
@@ -2277,9 +2277,12 @@
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
     },
     "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
+      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -3844,17 +3847,17 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/pem": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.4.tgz",
-      "integrity": "sha512-v8lH3NpirgiEmbOqhx0vwQTxwi0ExsiWBGYh0jYNq7K6mQuO4gI6UEFlr6fLAdv9TPXRt6GqiwE37puQdIDS8g==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.8.tgz",
+      "integrity": "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==",
       "dependencies": {
-        "es6-promisify": "^6.0.0",
-        "md5": "^2.2.1",
-        "os-tmpdir": "^1.0.1",
+        "es6-promisify": "^7.0.0",
+        "md5": "^2.3.0",
+        "os-tmpdir": "^1.0.2",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -7842,9 +7845,9 @@
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
     },
     "es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
+      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -9052,13 +9055,13 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pem": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.4.tgz",
-      "integrity": "sha512-v8lH3NpirgiEmbOqhx0vwQTxwi0ExsiWBGYh0jYNq7K6mQuO4gI6UEFlr6fLAdv9TPXRt6GqiwE37puQdIDS8g==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.8.tgz",
+      "integrity": "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==",
       "requires": {
-        "es6-promisify": "^6.0.0",
-        "md5": "^2.2.1",
-        "os-tmpdir": "^1.0.1",
+        "es6-promisify": "^7.0.0",
+        "md5": "^2.3.0",
+        "os-tmpdir": "^1.0.2",
         "which": "^2.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.20",
     "nedb-promises": "^5.0.1",
     "nedb-promises-session-store": "1.0.0",
-    "pem": "^1.14.4",
+    "pem": "^1.14.7",
     "prompts": "^2.4.2",
     "readline": "^1.3.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Updating the pem package from v1.14.4 to v1.14.7 addresses a bug where the web server's web_certs.json doesn't generate with openssl 3, which consequentially prevents using https on the Web UI.
This small fix would allow web_certs.json to generate correctly with systems using openssl 3, allowing https again.

I tested this with OpenSSL 3.0.2 15 Mar 2022, but I don't see any reason why this would break older versions.