### PR TITLE
feat(worlds,steam): load world on restart, steam auto updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ Read the README first before asking questions! [Join the discord](https://discor
 
 Omegga wraps brickadia's server console to provide interactivity and utility via plugins.
 
+Omegga can do things like:
+
+- Automatically update/restart your server
+- Manage your worlds from a web interface and load a world on startup/restart
+- Chat with players while not on the server
+- Read chat history with timestamps
+- See kick and ban history
+- Configure plugins from a web interface
+
 Omegga plugins can do things like:
 
-- Add custom chat commands
+- Add custom chat !commands and /commands
 - Respond to and send chat messages
 - Load bricks to player's clipboards
 - Load/Clear regions of bricks

--- a/frontend/src/components/header/header.scss
+++ b/frontend/src/components/header/header.scss
@@ -11,4 +11,9 @@
   padding-left: 20px;
   padding-right: 10px;
   text-transform: uppercase;
+
+  &.attached {
+    border-top-left-radius: theme.$br-radius-md;
+    border-top-right-radius: theme.$br-radius-md;
+  }
 }

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -4,9 +4,14 @@ import type React from 'react';
 export const Header = ({
   children,
   className,
+  attached,
   ...props
-}: React.PropsWithChildren & HTMLAttributes<HTMLDivElement>) => (
-  <div className={`header ${className ?? ''}`} {...props}>
+}: React.PropsWithChildren &
+  HTMLAttributes<HTMLDivElement> & { attached?: boolean }) => (
+  <div
+    className={`header ${attached ? 'attached' : ''} ${className ?? ''}`}
+    {...props}
+  >
     {children}
   </div>
 );

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -10,7 +10,7 @@ export { InfiniteScroll } from './infinite-scroll';
 export { Input } from './input';
 export { ListInput, type ListInputType } from './list-input';
 export { Loader } from './loader';
-export { Modal } from './modal';
+export { Modal, useConfirm } from './modal';
 export { NavBar, NavHeader } from './navbar';
 export { Page, PageContent } from './page';
 export { PlayerDropdown } from './player-dropdown';

--- a/frontend/src/components/modal/index.tsx
+++ b/frontend/src/components/modal/index.tsx
@@ -1,4 +1,15 @@
-import type { PropsWithChildren } from 'react';
+import { IconCheck, IconX } from '@tabler/icons-react';
+import {
+  useCallback,
+  useState,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react';
+import { Button } from '../button';
+import { Dimmer } from '../dimmer';
+import { Footer } from '../footer';
+import { Header } from '../header';
+import { PopoutContent } from '../popout';
 
 export const Modal = ({
   visible,
@@ -8,3 +19,73 @@ export const Modal = ({
     <div className="modal-content">{children}</div>
   </div>
 );
+
+export const useConfirm = <T = boolean,>({
+  leftButton,
+  rightButton,
+  title,
+  content,
+}: {
+  title?: string;
+  content?: ReactNode;
+  leftButton?: (confirm: (ok: T) => void) => React.ReactNode;
+  rightButton?: (confirm: (ok: T) => void) => React.ReactNode;
+} = {}) => {
+  const [confirm, setConfim] = useState({
+    show: false,
+    message: '',
+    children: null as ReactNode | null,
+    resolve: (_val: T) => {},
+  });
+  const prompt = useCallback(
+    (message?: string | ReactNode) =>
+      new Promise<T>(resolve => {
+        setConfim({
+          message: typeof message === 'string' ? message : '',
+          children: typeof message !== 'string' && message ? message : null,
+          show: true,
+          resolve(val: T) {
+            resolve(val);
+            setConfim({
+              show: false,
+              message: '',
+              children: null,
+              resolve: () => {},
+            });
+          },
+        });
+      }),
+    [],
+  );
+
+  return {
+    prompt,
+    children: (
+      <Dimmer visible={confirm.show}>
+        <Modal visible>
+          <Header attached>{title ?? 'Confirmation'}</Header>
+          <PopoutContent>
+            {content ?? confirm.children ?? (
+              <p>Are you sure you want to {confirm.message}?</p>
+            )}
+          </PopoutContent>
+          <Footer attached>
+            {leftButton?.(confirm.resolve) ?? (
+              <Button main onClick={() => confirm.resolve(true as T)}>
+                <IconCheck />
+                Yes
+              </Button>
+            )}
+            <div style={{ flex: 1 }} />
+            {rightButton?.(confirm.resolve) ?? (
+              <Button normal onClick={() => confirm.resolve(false as T)}>
+                <IconX />
+                No
+              </Button>
+            )}
+          </Footer>
+        </Modal>
+      </Dimmer>
+    ),
+  };
+};

--- a/frontend/src/components/sidenav/index.tsx
+++ b/frontend/src/components/sidenav/index.tsx
@@ -5,6 +5,7 @@ import {
   IconPlug,
   IconServer,
   IconUser,
+  IconWorld,
 } from '@tabler/icons-react';
 import type React from 'react';
 import { memo, type AnchorHTMLAttributes } from 'react';
@@ -39,6 +40,10 @@ export const SideNav = memo(() => (
     >
       <IconDashboard style={{ background: '#de4f43' }} />
       Dashboard
+    </MenuButton>
+    <MenuButton to="/worlds" data-tooltip="Manage worlds">
+      <IconWorld style={{ background: '#f0a500' }} />
+      Worlds
     </MenuButton>
     <MenuButton to="/history" data-tooltip="Browse chat history">
       <IconMessages style={{ background: '#008bd6' }} />

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,6 +10,7 @@ import { PlayerList } from './views/players/PlayerList';
 import { PluginList } from './views/plugins';
 import { ServerView } from './views/server';
 import { UserList } from './views/users';
+import { WorldList } from './views/worlds/WorldList';
 
 const App = () => (
   <Page>
@@ -17,10 +18,11 @@ const App = () => (
       <Switch>
         <Route path="/" component={HomeView} />
         <Route path="/history/:time?" component={HistoryView} />
-        <Route path="/plugins/:id?" component={PluginList} />
         <Route path="/players/:id?" component={PlayerList} />
-        <Route path="/users/:id?" component={UserList} />
+        <Route path="/plugins/:id?" component={PluginList} />
         <Route path="/server" component={ServerView} />
+        <Route path="/users/:id?" component={UserList} />
+        <Route path="/worlds/*?" component={WorldList} />
         <Route component={NotFound} />
       </Switch>
     </Router>

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,3 +1,4 @@
+import type { OmeggaSocketData } from '@omegga/webserver/backend/api';
 import {
   JSONRPCClient,
   JSONRPCServer,
@@ -6,13 +7,7 @@ import {
 import io from 'socket.io-client';
 import { $rpcConnected, $rpcDisconnected } from './stores/connected';
 import { $liveness } from './stores/liveness';
-import {
-  $omeggaData,
-  $roles,
-  $showLogout,
-  $user,
-  type OmeggaSocketData,
-} from './stores/user';
+import { $omeggaData, $roles, $showLogout, $user } from './stores/user';
 import { $version } from './stores/version';
 
 export const socket = io();

--- a/frontend/src/stores/liveness.ts
+++ b/frontend/src/stores/liveness.ts
@@ -1,7 +1,7 @@
-import { atom } from 'nanostores';
-import { ioEmit, rpcReq } from '../socket';
-import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
+import { atom } from 'nanostores';
+import { useEffect } from 'react';
+import { ioEmit, rpcReq } from '../socket';
 
 export const $liveness = atom<{
   starting: boolean;
@@ -49,4 +49,8 @@ export const stopServer = () => {
 export const restartServer = () => {
   $liveness.set({ ...$liveness.get(), loading: true });
   rpcReq('server.restart');
+};
+export const updateServer = () => {
+  $liveness.set({ ...$liveness.get(), loading: true });
+  rpcReq('server.update');
 };

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -1,17 +1,5 @@
+import type { OmeggaSocketData } from '@omegga/webserver/backend/api';
 import { atom } from 'nanostores';
-
-export type OmeggaSocketData = {
-  roles: { type: 'role'; name: string }[];
-  version: string;
-  canLogOut: boolean;
-  now: number;
-  userless: boolean;
-  user: {
-    username: string;
-    isOwner: boolean;
-    roles: string[];
-  };
-};
 
 export const $showLogout = atom(false);
 export const $user = atom<OmeggaSocketData['user'] | null>(null);

--- a/frontend/src/stores/worlds.ts
+++ b/frontend/src/stores/worlds.ts
@@ -1,0 +1,4 @@
+import { atom } from 'nanostores';
+
+export const $nextWorld = atom<string | null>(null);
+export const $activeWorld = atom<string | null>(null);

--- a/frontend/src/views/_index.scss
+++ b/frontend/src/views/_index.scss
@@ -1,5 +1,6 @@
-@use 'server';
 @use 'history';
+@use 'home';
 @use 'players';
 @use 'plugins';
-@use 'home';
+@use 'server';
+@use 'worlds';

--- a/frontend/src/views/players/player-list.scss
+++ b/frontend/src/views/players/player-list.scss
@@ -114,6 +114,7 @@
   background-color: theme.$br-element-popout-bg;
   flex: 1;
   position: relative;
-  border-radius: theme.$br-radius-md;
+  border-bottom-left-radius: theme.$br-radius-md;
+  border-bottom-right-radius: theme.$br-radius-md;
   overflow: hidden;
 }

--- a/frontend/src/views/plugins/plugin-list.scss
+++ b/frontend/src/views/plugins/plugin-list.scss
@@ -78,5 +78,6 @@
   background-color: theme.$br-element-popout-bg;
   flex: 1;
   position: relative;
-  border-radius: theme.$br-radius-md;
+  border-bottom-left-radius: theme.$br-radius-md;
+  border-bottom-right-radius: theme.$br-radius-md;
 }

--- a/frontend/src/views/server/index.tsx
+++ b/frontend/src/views/server/index.tsx
@@ -75,10 +75,8 @@ export const ServerView = () => {
       dailyHour: Math.round(Math.max(0, Math.min(config.dailyHour, 23))),
       dailyHourEnabled: config.dailyHourEnabled,
       announcementEnabled: config.announcementEnabled,
-      bricksEnabled: config.bricksEnabled,
       playersEnabled: config.playersEnabled,
-      minigamesEnabled: config.minigamesEnabled,
-      environmentEnabled: config.environmentEnabled,
+      saveWorld: config.saveWorld,
     };
     rpcNotify('server.autorestart.set', blob);
   }, [config]);
@@ -134,7 +132,7 @@ export const ServerView = () => {
             </Button>
             <Button
               warn
-              data-tooltip="Stop the server if it's running, then start the server. Saves minigames/environment/bricks if enabled below."
+              data-tooltip="Reloads the server's world. Saves minigames/environment/bricks if 'Save World' is enabled below."
               disabled={starting || stopping || statusLoading}
               onClick={() =>
                 prompt('restart the server').then(ok => ok && restartServer())
@@ -238,40 +236,14 @@ export const ServerView = () => {
               </div>
               <div
                 className="inputs-item"
-                data-tooltip="When enabled, saves and re-loads bricks on autorestart"
+                data-tooltip="When enabled, saves the current world. The default world will be loaded on restart"
               >
-                <label>Reload Bricks</label>
+                <label>Save World</label>
                 <div className="inputs">
                   <Toggle
                     tooltip="Enabled"
-                    value={config.bricksEnabled}
-                    onChange={changeConfig('bricksEnabled')}
-                  />
-                </div>
-              </div>
-              <div
-                className="inputs-item"
-                data-tooltip="When enabled, saves and re-loads minigames on autorestart"
-              >
-                <label>Reload Minigames</label>
-                <div className="inputs">
-                  <Toggle
-                    tooltip="Enabled"
-                    value={config.minigamesEnabled}
-                    onChange={changeConfig('minigamesEnabled')}
-                  />
-                </div>
-              </div>
-              <div
-                className="inputs-item"
-                data-tooltip="When enabled, saves and re-loads environment on autorestart"
-              >
-                <label>Reload Environment</label>
-                <div className="inputs">
-                  <Toggle
-                    tooltip="Enabled"
-                    value={config.environmentEnabled}
-                    onChange={changeConfig('environmentEnabled')}
+                    value={config.saveWorld ?? true}
+                    onChange={changeConfig('saveWorld')}
                   />
                 </div>
               </div>

--- a/frontend/src/views/server/index.tsx
+++ b/frontend/src/views/server/index.tsx
@@ -77,7 +77,11 @@ export const ServerView = () => {
       announcementEnabled: config.announcementEnabled,
       playersEnabled: config.playersEnabled,
       saveWorld: config.saveWorld,
-    };
+      autoUpdateEnabled: config.autoUpdateEnabled ?? true,
+      autoUpdateIntervalMins: Math.round(
+        Math.max(10, Math.min(config.autoUpdateIntervalMins ?? 60, Infinity)),
+      ),
+    } satisfies IStoreAutoRestartConfig;
     rpcNotify('server.autorestart.set', blob);
   }, [config]);
 
@@ -86,7 +90,10 @@ export const ServerView = () => {
   const changeConfig = <K extends keyof IStoreAutoRestartConfig>(name: K) => {
     return (value: IStoreAutoRestartConfig[K]) => {
       if (!config) return;
-      config[name] = value;
+      setConfig(prev => ({
+        ...prev!,
+        [name]: value,
+      }));
       saved.fire();
     };
   };
@@ -148,6 +155,26 @@ export const ServerView = () => {
           </NavBar>
           {config && (
             <div className="inputs-list">
+              <div
+                className="inputs-item"
+                data-tooltip="When enabled on servers setup with SteamCMD, automatically updates the server when a new version is available"
+              >
+                <label>Auto Update (SteamCMD Only)</label>
+                <div className="inputs">
+                  <Toggle
+                    tooltip="Enabled"
+                    value={config.autoUpdateEnabled}
+                    onChange={changeConfig('autoUpdateEnabled')}
+                  />
+                  <Input
+                    type="number"
+                    placeholder="Minutes"
+                    tooltip="Interval in minutes to check for updates (min 10)"
+                    value={config.autoUpdateIntervalMins}
+                    onChange={changeConfig('autoUpdateIntervalMins')}
+                  />
+                </div>
+              </div>
               <div
                 className="inputs-item"
                 data-tooltip="How many hours before restarting regardless of online players"

--- a/frontend/src/views/worlds/WorldInspector.tsx
+++ b/frontend/src/views/worlds/WorldInspector.tsx
@@ -1,0 +1,205 @@
+import { Button, Footer, Loader, Scroll, useConfirm } from '@components';
+import { useStore } from '@nanostores/react';
+import type { WorldRevisionsRes } from '@omegga/webserver/backend/api';
+import { IconPlayerPlay, IconStar, IconStarOff } from '@tabler/icons-react';
+import { useEffect, useRef, useState } from 'react';
+import { useRoute } from 'wouter';
+import { rpcReq } from '../../socket';
+import { $liveness } from '../../stores/liveness';
+import { $activeWorld, $nextWorld } from '../../stores/worlds';
+
+export const WorldInspector = () => {
+  const [_location, params] = useRoute('/worlds/*');
+  const selectedWorld = params?.['*'];
+  const [waiting, setWaiting] = useState(false);
+  const nextWorld = useStore($nextWorld);
+  const activeWorld = useStore($activeWorld);
+  const liveness = useStore($liveness);
+
+  const [loading, setLoading] = useState(false);
+  const [revisions, setRevisions] = useState<WorldRevisionsRes | null>(null);
+  const selectedWorldRef = useRef(selectedWorld);
+  selectedWorldRef.current = selectedWorld;
+
+  const confirm = useConfirm();
+
+  // Load the revisions if the world is selected and the server is started
+  // TODO: load revisions by parsing the brdb file
+  useEffect(() => {
+    if (!selectedWorld || !liveness.started) return;
+    setLoading(true);
+    setRevisions(null);
+    rpcReq('world.revisions', selectedWorld).then(revs => {
+      if (selectedWorldRef.current !== selectedWorld) return;
+      setRevisions(revs?.reverse() ?? null);
+      setLoading(false);
+    });
+  }, [selectedWorld, liveness.started]);
+
+  const setWorldActive = async () => {
+    if (!selectedWorld) return;
+    setWaiting(true);
+    const ok = await rpcReq('world.use', selectedWorld);
+    if (ok) {
+      $activeWorld.set(selectedWorld);
+      $nextWorld.set(selectedWorld);
+    }
+    setWaiting(false);
+  };
+
+  const clearWorldActive = async () => {
+    if (!selectedWorld) return;
+    setWaiting(true);
+    const ok = await rpcReq('world.use');
+    if (ok) {
+      const nextWorld = await rpcReq('world.next');
+      const active = await rpcReq('world.active');
+      $activeWorld.set(active);
+      $nextWorld.set(nextWorld);
+    }
+    setWaiting(false);
+  };
+
+  const loadWorld = async (revision?: number) => {
+    if (!selectedWorld) return;
+    setWaiting(true);
+    const ok = await rpcReq('world.load', selectedWorld, revision ?? null);
+    // TODO: handle this status?
+    console.info('world loaded', ok);
+    setWaiting(false);
+  };
+
+  return (
+    <div className="world-view">
+      <div className="world-info">
+        {selectedWorld && (
+          <Scroll>
+            <div className="stats">
+              <div className="stat">
+                <b data-tooltip="World name">Name:</b> {selectedWorld}
+              </div>
+              <div className="stat">
+                <b data-tooltip="If yes, this world will be loaded on the next server start">
+                  Is Default:
+                </b>{' '}
+                {activeWorld === selectedWorld ? 'Yes' : 'No'}
+              </div>
+              {nextWorld !== activeWorld && (
+                <div className="stat">
+                  <b data-tooltip="Whether this world is configured to load next start if no other default is specified">
+                    Is Fallback World:
+                  </b>{' '}
+                  {nextWorld === selectedWorld ? 'Yes' : 'No'}
+                </div>
+              )}
+              {/* TODO: parse the brdb */}
+            </div>
+            <div
+              className="section-header"
+              data-tooltip="Ways to configure the plugin. Changes take place the next time a plugin is loaded."
+            >
+              Revisions
+            </div>
+            <div className="revision-list">
+              <Loader active={loading} size="huge">
+                Loading World
+              </Loader>
+              {revisions?.length === 0 && (
+                <div className="revision-item">
+                  <i className="revision-note">
+                    Something went wrong listing the revisions
+                  </i>
+                </div>
+              )}
+              {revisions === null && !loading && liveness.started && (
+                <div className="revision-item">
+                  <i className="revision-note">World might not exist</i>
+                </div>
+              )}
+              {revisions?.map(r => (
+                <div className="revision-item config" key={r.index}>
+                  <div className="revision-index">{r.index}</div>
+                  <div className="revision-note">
+                    {r.note}
+                    <div className="revision-date">
+                      {new Date(r.date).toLocaleString()}
+                    </div>
+                  </div>
+                  <Button
+                    icon
+                    main
+                    disabled={waiting || !liveness.started}
+                    onClick={() =>
+                      confirm
+                        .prompt(
+                          <p>
+                            Are you sure you want to load revision {r.index} of{' '}
+                            <b style={{ color: 'white' }}>{selectedWorld}</b>?
+                            Unsaved work will be lost.
+                          </p>,
+                        )
+                        .then(ok => {
+                          ok && loadWorld(r.index);
+                        })
+                    }
+                    data-tooltip={`Load revision ${r.index}`}
+                  >
+                    <IconPlayerPlay />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </Scroll>
+        )}
+      </div>
+      <Footer attached>
+        {activeWorld !== selectedWorld && (
+          <Button
+            normal
+            disabled={waiting || !selectedWorld}
+            data-tooltip="Make this the default world for the server (on startup)"
+            onClick={() => setWorldActive()}
+          >
+            <IconStar />
+            Make Default
+          </Button>
+        )}
+        {activeWorld === selectedWorld && (
+          <Button
+            warn
+            disabled={waiting || !selectedWorld}
+            data-tooltip="Remove this world as the default world for the server (on startup)"
+            onClick={() => clearWorldActive()}
+          >
+            <IconStarOff />
+            Clear Default
+          </Button>
+        )}
+        <span style={{ flex: 1 }} />
+
+        <Button
+          main
+          data-tooltip="Load this world immediately"
+          disabled={waiting || !liveness.started || !selectedWorld}
+          onClick={() =>
+            confirm
+              .prompt(
+                <p>
+                  Are you sure you want to load{' '}
+                  <b style={{ color: 'white' }}>{selectedWorld}</b>? Unsaved
+                  work will be lost.
+                </p>,
+              )
+              .then(ok => {
+                ok && loadWorld();
+              })
+          }
+        >
+          <IconPlayerPlay />
+          Load
+        </Button>
+      </Footer>
+      {confirm.children}
+    </div>
+  );
+};

--- a/frontend/src/views/worlds/WorldList.tsx
+++ b/frontend/src/views/worlds/WorldList.tsx
@@ -1,0 +1,314 @@
+import {
+  Button,
+  Dropdown,
+  Input,
+  Loader,
+  NavBar,
+  NavHeader,
+  PageContent,
+  Scroll,
+  SideNav,
+  useConfirm,
+} from '@components';
+import { useStore } from '@nanostores/react';
+import {
+  IconCaretDown,
+  IconCaretUp,
+  IconClipboardPlus,
+  IconDeviceFloppy,
+  IconPlus,
+  IconRotate,
+  IconSettingsStar,
+  IconStar,
+  IconStarOff,
+  IconWorld,
+  IconWorldPlus,
+  IconX,
+} from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+import { Link, useRoute } from 'wouter';
+import { rpcReq } from '../../socket';
+import { useServerLiveness } from '../../stores/liveness';
+import { $activeWorld, $nextWorld } from '../../stores/worlds';
+import { WorldInspector } from './WorldInspector';
+
+const MAP_OPTIONS = ['Plate', 'Space', 'Studio', 'Peaks'];
+
+export const WorldList = () => {
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [worlds, setWorlds] = useState<string[]>([]);
+  const [waiting, setWaiting] = useState(false);
+  const nextWorld = useStore($nextWorld);
+  const activeWorld = useStore($activeWorld);
+  const [showWidgets, setShowWidgets] = useState(false);
+
+  const liveness = useServerLiveness();
+
+  const [_location, params] = useRoute('/worlds/*?');
+  const selectedWorld = params?.['*'];
+
+  const getWorlds = async () => {
+    setLoading(true);
+    const [worlds, active, next] = await Promise.all([
+      rpcReq('world.list'),
+      rpcReq('world.active'),
+      rpcReq('world.next'),
+    ]);
+    setWorlds(worlds);
+    $activeWorld.set(active);
+    $nextWorld.set(next);
+    setLoading(false);
+  };
+  useEffect(() => {
+    getWorlds();
+  }, []);
+
+  const clearActiveWorld = async () => {
+    setWaiting(true);
+    const ok = await rpcReq('world.use', null);
+    if (ok) {
+      $activeWorld.set(null);
+      const next = await rpcReq('world.next');
+      $nextWorld.set(next);
+    }
+    setWaiting(false);
+  };
+
+  const saveWorld = async () => {
+    setWaiting(true);
+    await rpcReq('world.save');
+    setWaiting(false);
+  };
+
+  const saveWorldAs = async (name: string) => {
+    setWaiting(true);
+    await rpcReq('world.save', name);
+    setWaiting(false);
+    getWorlds();
+  };
+
+  const createWorld = async (name: string, map: string) => {
+    setWaiting(true);
+    await rpcReq('world.create', name, map);
+    setWaiting(false);
+    getWorlds();
+  };
+
+  const matches = (w: string) => w.toLowerCase().includes(search.toLowerCase());
+  const [worldName, setWorldName] = useState<string | null>(null);
+  const saveAsConfirm = useConfirm<string | null>({
+    title: 'Save World As',
+    content: (
+      <>
+        <p>Enter a name for the new world</p>
+        <p>
+          <Input
+            type="text"
+            placeholder="World Name"
+            value={worldName ?? ''}
+            onChange={s => setWorldName(s)}
+          />
+        </p>
+      </>
+    ),
+    leftButton: done => (
+      <Button normal onClick={() => done(null)}>
+        <IconX />
+        Cancel
+      </Button>
+    ),
+    rightButton: done => (
+      <Button disabled={!worldName} main onClick={() => done(worldName)}>
+        <IconPlus />
+        Save As
+      </Button>
+    ),
+  });
+  const [newMap, setNewMap] = useState<string>('Plate');
+  const newMapConfirm = useConfirm<{ name: string; map: string } | null>({
+    title: 'Create New World',
+    content: (
+      <>
+        <p>Select a name and map for the new world</p>
+        <p>
+          <Input
+            type="text"
+            placeholder="World Name"
+            value={worldName ?? ''}
+            onChange={s => setWorldName(s)}
+          />
+        </p>
+        <p>
+          <Dropdown
+            value={newMap}
+            options={MAP_OPTIONS}
+            onChange={v => setNewMap(v as string)}
+          />
+        </p>
+      </>
+    ),
+    leftButton: done => (
+      <Button normal onClick={() => done(null)}>
+        <IconX />
+        Cancel
+      </Button>
+    ),
+    rightButton: done => (
+      <Button
+        disabled={!worldName}
+        main
+        onClick={() => done({ name: worldName!, map: newMap })}
+      >
+        <IconPlus />
+        Create
+      </Button>
+    ),
+  });
+
+  return (
+    <>
+      <NavHeader title="Worlds">
+        <div className="widgets-container worlds">
+          <Button
+            normal
+            boxy
+            data-tooltip="Show more world actions"
+            onClick={() => setShowWidgets(!showWidgets)}
+          >
+            {showWidgets ? <IconCaretUp /> : <IconCaretDown />}
+            Actions
+          </Button>
+          <div
+            className="widgets-list"
+            style={{ display: showWidgets ? 'block' : 'none' }}
+          >
+            <Button
+              info
+              disabled={waiting || !liveness.started}
+              data-tooltip="Save the currently loaded world"
+              onClick={() => {
+                setShowWidgets(false);
+                saveWorld();
+              }}
+            >
+              <IconDeviceFloppy />
+              Save World
+            </Button>
+            <Button
+              normal
+              disabled={waiting || !liveness.started}
+              data-tooltip="Save a copy of the currently loaded world"
+              onClick={() => {
+                setShowWidgets(false);
+                setWorldName(null);
+                saveAsConfirm.prompt().then(name => {
+                  name && saveWorldAs(name);
+                });
+              }}
+            >
+              <IconClipboardPlus />
+              Save As
+            </Button>
+            <Button
+              main
+              disabled={waiting || !liveness.started}
+              data-tooltip="Create a new world"
+              onClick={() => {
+                setShowWidgets(false);
+                setWorldName(null);
+                setNewMap('Plate');
+                newMapConfirm.prompt().then(data => {
+                  if (data) {
+                    createWorld(data.name, data.map);
+                  }
+                });
+              }}
+            >
+              <IconWorldPlus />
+              New World
+            </Button>
+            <Button
+              normal={activeWorld === null}
+              warn={activeWorld !== null}
+              disabled={waiting || !activeWorld}
+              data-tooltip="Remove the default world for the server (on startup)"
+              onClick={() => {
+                setShowWidgets(false);
+                clearActiveWorld();
+              }}
+            >
+              <IconStarOff />
+              Clear Default
+            </Button>
+          </div>
+        </div>
+      </NavHeader>
+      <PageContent>
+        <SideNav />
+        <div className="generic-container worlds-container">
+          <div className="worlds-list-container">
+            <NavBar>
+              <Input
+                type="text"
+                placeholder="Search Worlds..."
+                value={search}
+                onChange={s => setSearch(s)}
+              />
+              <span style={{ flex: 1 }} />
+              <Button
+                icon
+                normal
+                data-tooltip="Refresh world list"
+                onClick={getWorlds}
+              >
+                <IconRotate />
+              </Button>
+            </NavBar>
+            <div className="worlds-list">
+              <Scroll>
+                {worlds.map(
+                  w =>
+                    matches(w) && (
+                      <Link
+                        href={'/worlds/' + w}
+                        key={w}
+                        className={`world-item ${
+                          w === selectedWorld ? 'selected' : ''
+                        }`}
+                        data-tooltip={
+                          w === nextWorld
+                            ? 'This world will load when the server starts'
+                            : ''
+                        }
+                      >
+                        {w === activeWorld ? (
+                          <IconStar className="world-item-active" />
+                        ) : !activeWorld && w === nextWorld ? (
+                          <IconSettingsStar className="world-item-next" />
+                        ) : (
+                          <IconWorld />
+                        )}
+                        {w}
+                      </Link>
+                    ),
+                )}
+              </Scroll>
+              <Loader active={loading} size="huge">
+                Loading Worlds
+              </Loader>
+            </div>
+          </div>
+          <div className="world-inspector-container">
+            <NavBar attached>{selectedWorld ?? 'SELECT A WORLD'}</NavBar>
+            <div className="world-inspector">
+              <WorldInspector />
+            </div>
+          </div>
+        </div>
+      </PageContent>
+      {saveAsConfirm.children}
+      {newMapConfirm.children}
+    </>
+  );
+};

--- a/frontend/src/views/worlds/_index.scss
+++ b/frontend/src/views/worlds/_index.scss
@@ -1,0 +1,2 @@
+@use 'world-inspector';
+@use 'world-list';

--- a/frontend/src/views/worlds/index.tsx
+++ b/frontend/src/views/worlds/index.tsx
@@ -1,0 +1,1 @@
+export { WorldList as PluginList } from './WorldList';

--- a/frontend/src/views/worlds/world-inspector.scss
+++ b/frontend/src/views/worlds/world-inspector.scss
@@ -1,0 +1,66 @@
+@use '../../css/theme';
+@use '../../css/mixins';
+
+.world-view,
+.world-info {
+  @include mixins.column-container;
+
+  .scroll-scroller {
+    background-color: theme.$br-bg-primary;
+  }
+}
+
+.world-info {
+  .section-header {
+    @include mixins.center;
+    color: white;
+    height: 32px;
+    font-size: 24px;
+    text-shadow: none;
+    font-weight: bold;
+    text-align: center;
+    background-color: theme.$br-bg-header;
+    top: 0;
+    position: sticky;
+    text-transform: uppercase;
+  }
+}
+
+.revision-item {
+  @include mixins.alternate(
+    background-color,
+    theme.$br-bg-secondary,
+    theme.$br-bg-secondary-alt
+  );
+  font-size: 20px;
+  min-height: 60px;
+  overflow: visible;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  color: theme.$br-boring-button-fg;
+
+  .revision-note {
+    color: theme.$br-button-fg;
+    flex: 1;
+  }
+
+  .revision-index {
+    width: 40px;
+    margin-left: 8px;
+    margin-right: 16px;
+    text-align: right;
+    color: theme.$br-info-normal;
+  }
+
+  .revision-date {
+    color: theme.$br-boring-button-fg;
+
+    font-size: 12px;
+  }
+
+  .button {
+    margin-right: 16px;
+  }
+}

--- a/frontend/src/views/worlds/world-list.scss
+++ b/frontend/src/views/worlds/world-list.scss
@@ -1,0 +1,97 @@
+@use '../../css/theme';
+@use '../../css/mixins';
+
+.worlds.widgets-container .widgets-list {
+  .button {
+    border-radius: 0;
+    margin-right: 0;
+  }
+  .button:first-child {
+    border-top-left-radius: theme.$br-radius-md;
+    border-top-right-radius: theme.$br-radius-md;
+  }
+  .button:last-child {
+    border-bottom-left-radius: theme.$br-radius-md;
+    border-bottom-right-radius: theme.$br-radius-md;
+  }
+}
+.worlds-container {
+  display: flex;
+  align-items: stretch;
+}
+
+.worlds-list-container,
+.world-inspector-container {
+  @include mixins.column-container;
+}
+
+.worlds-list-container {
+  margin-right: 16px;
+
+  .input {
+    max-width: 300px;
+    margin-right: 8px;
+    flex: 1;
+    width: 100%;
+  }
+}
+
+.worlds-list {
+  @include mixins.column-container;
+  margin-top: 8px;
+
+  .world-item {
+    background-color: theme.$br-button-normal;
+    margin-bottom: 8px;
+    margin-right: 8px;
+    display: flex;
+    align-items: center;
+    height: 48px;
+    font-size: 20px;
+    color: white;
+    cursor: pointer;
+    font-weight: bold;
+    text-decoration: none;
+    border-radius: theme.$br-radius-md;
+
+    &:hover,
+    .router-link-active {
+      background-color: theme.$br-element-hover;
+    }
+    &:active,
+    &.disabled {
+      background-color: theme.$br-element-pressed;
+    }
+
+    .tabler-icon {
+      @include mixins.center;
+      height: 32px;
+      width: 32px;
+      margin-left: 8px;
+      margin-right: 8px;
+      border-radius: theme.$br-radius-sm;
+
+      &.running {
+        background-color: theme.$br-main-normal;
+      }
+      &.bugged {
+        background-color: theme.$br-warn-normal;
+      }
+      &.broken {
+        background-color: theme.$br-error-normal;
+      }
+      &.disabled {
+        background-color: theme.$br-bg-primary;
+      }
+    }
+  }
+}
+
+.world-inspector {
+  @include mixins.column;
+  background-color: theme.$br-element-popout-bg;
+  flex: 1;
+  position: relative;
+  border-bottom-left-radius: theme.$br-radius-md;
+  border-bottom-right-radius: theme.$br-radius-md;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "simple-git": "^3.6.0",
         "socket.io": "^4.8.1",
         "source-map-support": "^0.5.21",
+        "steam-acf2json": "^0.1.1",
         "strip-ansi": "^6.0.1",
         "swc-loader": "^0.2.0",
         "update-notifier-cjs": "^5.1.6",
@@ -8472,6 +8473,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/steam-acf2json": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/steam-acf2json/-/steam-acf2json-0.1.1.tgz",
+      "integrity": "sha512-gBWW1BWz18mi99y4vVeRyrUyLEocrIE0KBCZ9dVfMbPrvqBxL5cwa1vvsPDXGAJY6CRJRMvxpkKEqV/5kBgrxA==",
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -15866,6 +15873,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "steam-acf2json": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/steam-acf2json/-/steam-acf2json-0.1.1.tgz",
+      "integrity": "sha512-gBWW1BWz18mi99y4vVeRyrUyLEocrIE0KBCZ9dVfMbPrvqBxL5cwa1vvsPDXGAJY6CRJRMvxpkKEqV/5kBgrxA=="
     },
     "stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "simple-git": "^3.6.0",
     "socket.io": "^4.8.1",
     "source-map-support": "^0.5.21",
+    "steam-acf2json": "^0.1.1",
     "strip-ansi": "^6.0.1",
     "swc-loader": "^0.2.0",
     "update-notifier-cjs": "^5.1.6",

--- a/src/brickadia/server.ts
+++ b/src/brickadia/server.ts
@@ -7,7 +7,6 @@ import Logger from '@/logger';
 import {
   ACTIVE_WORLD_FILE,
   CONFIG_SAVED_DIR,
-  DATA_PATH,
   GAME_BIN_PATH,
   GAME_DIRNAME,
   GAME_INSTALL_DIR,

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -181,11 +181,10 @@ const COMMANDS: TerminalCommand[] = [
           steambeta: this.omegga.config.server?.steambeta,
           steambetaPassword: this.omegga.config.server?.steambetaPassword,
         });
+        log('Server updated successfully.');
       } catch (e) {
         err('An error occurred while updating the server:', e);
-        return;
       }
-      log('Server updated successfully.');
       if (wasStarted) {
         log('Starting server...');
         await this.omegga.start();

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -158,6 +158,12 @@ const COMMANDS: TerminalCommand[] = [
     aliases: ['update'],
     desc: 'try to update the server and restart if started (without announcement or saving',
     async fn() {
+      if (!this.omegga.config.__STEAM) {
+        err(
+          'This command is only available when the server is installed via SteamCMD',
+        );
+        return;
+      }
       if (this.omegga.stopping || this.omegga.starting) {
         err(
           'The server is currently starting or stopping. Please wait a moment',

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -641,7 +641,12 @@ Players: ${status.players.length === 0 ? 'none'.grey : ''}
 
           // save the current world
           log('Saving current world...');
-          this.omegga.saveWorld();
+          const res = await this.omegga.saveWorld();
+          if (res) {
+            log('Current world saved successfully.');
+          } else {
+            err('Failed to save the current world');
+          }
           return;
 
         case 'revisions':

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -42,6 +42,8 @@ export interface IConfig {
     password?: string;
     token?: string;
   };
+  /** Internal use - this is a steam install */
+  __STEAM?: boolean;
 }
 
 export type IConfigFormat = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -6,7 +6,11 @@ export interface IServerConfig {
 
 export interface IBrickadiaConfig {
   port: number;
+  /** Map to load on startup if a world is not specified */
   map?: string;
+  /** World file name to load on startup */
+  world?: string;
+
   /** old launcher branch name */
   branch?: string;
   /** Steam beta name */

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -364,7 +364,7 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   saveWorldAs(worldName: string) {
     throw badBorrow('saveWorldAs');
   }
-  saveWorld() {
+  saveWorld(): Promise<boolean> {
     throw badBorrow('saveWorld');
   }
   createEmptyWorld(worldName: string): Promise<void> {

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -355,13 +355,13 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   ): Promise<{ index: number; date: Date; note: string }[]> {
     throw badBorrow('getWorldRevisions');
   }
-  loadWorld(worldName: string) {
+  loadWorld(worldName: string): Promise<boolean> {
     throw badBorrow('loadWorld');
   }
-  loadWorldRevision(worldName: string, revision: number) {
+  loadWorldRevision(worldName: string, revision: number): Promise<boolean> {
     throw badBorrow('loadWorldRevision');
   }
-  saveWorldAs(worldName: string) {
+  saveWorldAs(worldName: string): Promise<boolean> {
     throw badBorrow('saveWorldAs');
   }
   saveWorld(): Promise<boolean> {

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -367,7 +367,7 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   saveWorld(): Promise<boolean> {
     throw badBorrow('saveWorld');
   }
-  createEmptyWorld(worldName: string): Promise<void> {
+  createEmptyWorld(worldName: string): Promise<boolean> {
     throw badBorrow('createEmptyWorld');
   }
   writeSaveData(saveName: string, saveData: WriteSaveObject) {

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -287,7 +287,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
           } catch (err) {
             Logger.error('Error removing omegga_temp_players.json', err);
           }
-        }, 10000);
+        }, 180000);
       }
     } catch (err) {
       Logger.error('Error restoring previous server state', err);
@@ -340,6 +340,14 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     }
     Logger.verbose('Stopping server');
     super.stop();
+
+    const res = await Promise.race([
+      new Promise(resolve => this.once('exit', () => resolve('exit'))),
+      // Timeout after 10 seconds
+      new Promise(resolve => setTimeout(() => resolve('timeout'), 10000)),
+    ]);
+
+    Logger.verbose('Stop result:', res);
     if (this.stopping) this.emit('server:stopped');
     this.stopping = false;
     this.started = false;

--- a/src/omegga/wrapper.ts
+++ b/src/omegga/wrapper.ts
@@ -74,6 +74,26 @@ class OmeggaWrapper extends EventEmitter {
     }
     return (super.emit as EventEmitter['emit'])(type, ...args);
   }
+
+  /** Get which world will be loaded on startup (form file, config, or env) */
+  getNextWorld() {
+    return this.#server.getNextWorld();
+  }
+
+  /** Get the configured default world */
+  getActiveWorld() {
+    return this.#server.getActiveWorld();
+  }
+
+  /** Configure the default world  */
+  setActiveWorld(world: string | null): boolean {
+    return this.#server.setActiveWorld(world);
+  }
+
+  /** Check if a world exists */
+  worldExists(file: string) {
+    return this.#server.worldExists(file);
+  }
 }
 
 export default OmeggaWrapper;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -758,7 +758,7 @@ export interface OmeggaCore {
   /**
    * Save the current world
    */
-  saveWorld(): void;
+  saveWorld(): Promise<boolean>;
 
   /**
    * Create an empty world with the given name

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -64,10 +64,8 @@ export interface BrickInteraction {
 /** AutoRestart options */
 export type AutoRestartConfig = {
   players: boolean;
-  bricks: boolean;
-  minigames: boolean;
-  environment: boolean;
   announcement: boolean;
+  saveWorld: boolean;
 };
 
 export interface OmeggaPlayer {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -763,7 +763,7 @@ export interface OmeggaCore {
   /**
    * Create an empty world with the given name
    */
-  createEmptyWorld(worldName: string): void;
+  createEmptyWorld(worldName: string): Promise<boolean>;
 
   /**
    * unsafely load save data (wrap in try/catch)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import {
   IServerStatus,
 } from '@omegga/types';
 import util from '@util';
-import brs, { ReadSaveObject, WriteSaveObject } from 'brs-js';
+import { ReadSaveObject, WriteSaveObject } from 'brs-js';
 
 export const _OMEGGA_UTILS_IMPORT = util;
 declare global {
@@ -741,19 +741,19 @@ export interface OmeggaCore {
    * Load a world by its name
    * @param worldName World name
    */
-  loadWorld(worldName: string): void;
+  loadWorld(worldName: string): Promise<boolean>;
 
   /**
    * Load a world at a specific revision
    * @param worldName World name
    */
-  loadWorldRevision(worldName: string, revision: number): void;
+  loadWorldRevision(worldName: string, revision: number): Promise<boolean>;
 
   /**
    * Save a world as a new name
    * @param worldName World name
    */
-  saveWorldAs(worldName: string): void;
+  saveWorldAs(worldName: string): Promise<boolean>;
 
   /**
    * Save the current world

--- a/src/softconfig.ts
+++ b/src/softconfig.ts
@@ -71,6 +71,7 @@ export const STATUS_STORE = 'status.db';
 export const USER_STORE = 'users.db';
 export const SERVER_STORE = 'store.db';
 export const SESSION_STORE = 'session.db';
+export const ACTIVE_WORLD_FILE = 'active_world';
 
 // website config
 export const WEB_CERTS_DATA = 'web_certs.json';

--- a/src/updater/index.ts
+++ b/src/updater/index.ts
@@ -1,0 +1,7 @@
+export {
+  steamcmdDownloadGame,
+  steamcmdDownloadSelf,
+  hasSteamUpdate,
+  getLocalSteamDepot,
+  getRemoteSteamDepot,
+} from './steam';

--- a/src/updater/steam-acf2json.d.ts
+++ b/src/updater/steam-acf2json.d.ts
@@ -1,0 +1,6 @@
+declare module 'steam-acf2json' {
+  export default {
+    decode: (data: string) => Record<string, unknown>,
+    encode: (data: Record<string, unknown>) => string,
+  };
+}

--- a/src/updater/steam.ts
+++ b/src/updater/steam.ts
@@ -1,0 +1,173 @@
+import Logger from '@/logger';
+import { GAME_INSTALL_DIR, STEAM_APP_ID, STEAMCMD_PATH } from '@/softconfig';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import acfParser from 'steam-acf2json';
+
+export function getAppId() {
+  return process.env.STEAM_APP_ID ?? STEAM_APP_ID;
+}
+
+export function steamcmdDownloadSelf() {
+  execSync(path.join(__dirname, '../../tools/install_steamcmd.sh'), {
+    stdio: 'inherit',
+  });
+}
+
+export function steamcmdDownloadGame({
+  steambeta,
+  steambetaPassword,
+}: {
+  steambeta?: string;
+  steambetaPassword?: string;
+} = {}) {
+  const args = [
+    `+force_install_dir ${path.join(GAME_INSTALL_DIR, steambeta ?? 'main')}`,
+    `+login anonymous`,
+    `+app_update ${getAppId()}`,
+    steambeta ? `-beta ${steambeta}` : null,
+    steambeta && steambetaPassword
+      ? `-betapassword ${steambetaPassword}`
+      : null,
+    '+quit',
+  ].filter(Boolean);
+
+  execSync(`${STEAMCMD_PATH} ${args.join(' ')}`, { stdio: 'inherit' });
+}
+
+export type SteamInfo = {
+  data: Record<
+    string,
+    {
+      _change_number: number;
+      _missing_token: boolean;
+      _sha: string;
+      _size: number;
+      appid: number;
+      common: unknown;
+      config: unknown;
+      depots: Record<
+        string,
+        {
+          config: { oslist: 'linux' | 'windows' | 'macos' };
+        }
+      > & {
+        branches: Record<
+          string,
+          {
+            buildid: string;
+            timeupdated: string;
+            description?: string;
+          }
+        >;
+        privatebranches: '1';
+      };
+    }
+  >;
+  status: 'success';
+};
+
+async function fetchSteamInfo() {
+  const appId = getAppId();
+  const res = await fetch('https://api.steamcmd.net/v1/info/' + appId);
+  const json = await res.json();
+  return json as SteamInfo;
+}
+
+export type SteamAcf = {
+  AppState: {
+    appid: string;
+    buildid: string;
+    lastupdated: string;
+  };
+};
+
+function getSteamAcf(steambeta?: string) {
+  const appId = getAppId();
+  const installDir = path.join(GAME_INSTALL_DIR, steambeta ?? 'main');
+  const acfPath = path.join(
+    installDir,
+    'steamapps',
+    `appmanifest_${appId}.acf`,
+  );
+  if (!existsSync(acfPath)) {
+    Logger.verbose(`File not found: ${acfPath}`);
+    return null;
+  }
+  try {
+    const plaintext = readFileSync(acfPath, 'utf-8');
+    const json = acfParser.decode(plaintext);
+    return json as SteamAcf;
+  } catch (err) {
+    Logger.error(`Error parsing ACF file ${acfPath}:`, err);
+    return null;
+  }
+}
+
+function getSteamDepot(info: SteamInfo, branch?: string) {
+  const appId = getAppId();
+  const depot =
+    info.data[appId]?.depots?.branches?.[
+      !branch || branch === 'main' ? 'public' : branch
+    ];
+  if (
+    !depot ||
+    typeof depot !== 'object' ||
+    !('buildid' in depot) ||
+    !('timeupdated' in depot)
+  )
+    return null;
+  return {
+    buildId: depot.buildid,
+    timeUpdated: Number(depot.timeupdated),
+  };
+}
+
+function getSteamAcfDepot(acf: SteamAcf) {
+  const appId = getAppId();
+  const appState = acf.AppState;
+  if (
+    !appState ||
+    typeof appState !== 'object' ||
+    appState.appid !== appId ||
+    !('buildid' in appState) ||
+    !('lastupdated' in appState)
+  )
+    return null;
+  return {
+    buildId: appState.buildid,
+    timeUpdated: Number(appState.lastupdated),
+  };
+}
+
+export function getLocalSteamDepot(steambeta?: string) {
+  const acf = getSteamAcf(steambeta);
+  if (!acf) return null;
+  const depot = getSteamAcfDepot(acf);
+  if (!depot) return null;
+  return depot;
+}
+
+export async function getRemoteSteamDepot(steambeta?: string) {
+  const info = await fetchSteamInfo();
+  if (!info || !info.data) {
+    return null;
+  }
+  const depot = getSteamDepot(info, steambeta);
+  if (!depot) return null;
+  return depot;
+}
+
+export async function hasSteamUpdate(steambeta?: string) {
+  const localDepot = getLocalSteamDepot(steambeta);
+  if (!localDepot) return false;
+
+  const remoteDepot = await getRemoteSteamDepot(steambeta);
+  if (!remoteDepot) return false;
+
+  return (
+    localDepot.buildId !== remoteDepot.buildId ||
+    localDepot.timeUpdated < remoteDepot.timeUpdated
+  );
+}

--- a/src/updater/steam.ts
+++ b/src/updater/steam.ts
@@ -159,15 +159,33 @@ export async function getRemoteSteamDepot(steambeta?: string) {
   return depot;
 }
 
+let lastUpdateCheck = 0;
+let lastUpdateAvailable = 0;
+let lastUpdateResult = false;
+
+export const getLastSteamUpdateCheck = () => ({
+  attempt: lastUpdateCheck,
+  available: lastUpdateAvailable,
+  result: lastUpdateResult,
+});
+
+export const clearLastSteamUpdateCheck = () => {
+  lastUpdateResult = false;
+};
+
 export async function hasSteamUpdate(steambeta?: string) {
+  lastUpdateCheck = Date.now();
   const localDepot = getLocalSteamDepot(steambeta);
   if (!localDepot) return false;
 
   const remoteDepot = await getRemoteSteamDepot(steambeta);
   if (!remoteDepot) return false;
 
-  return (
+  lastUpdateAvailable = Date.now();
+  const res =
     localDepot.buildId !== remoteDepot.buildId ||
-    localDepot.timeUpdated < remoteDepot.timeUpdated
-  );
+    localDepot.timeUpdated < remoteDepot.timeUpdated;
+  lastUpdateResult = res;
+
+  return res;
 }

--- a/src/webserver/backend/api.ts
+++ b/src/webserver/backend/api.ts
@@ -887,6 +887,8 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
       announcementEnabled: 'boolean',
       playersEnabled: 'boolean',
       saveWorld: 'boolean',
+      autoUpdateEnabled: 'boolean',
+      autoUpdateIntervalMins: 'number',
     };
 
     rpc.addMethod(

--- a/src/webserver/backend/api.ts
+++ b/src/webserver/backend/api.ts
@@ -885,10 +885,8 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
       dailyHour: 'number',
       dailyHourEnabled: 'boolean',
       announcementEnabled: 'boolean',
-      bricksEnabled: 'boolean',
-      minigamesEnabled: 'boolean',
-      environmentEnabled: 'boolean',
       playersEnabled: 'boolean',
+      saveWorld: 'boolean',
     };
 
     rpc.addMethod(
@@ -950,10 +948,8 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
         const config = await database.getAutoRestartConfig();
         await omegga.saveServer({
           players: config.playersEnabled,
-          bricks: config.bricksEnabled,
+          saveWorld: config.saveWorld ?? true,
           announcement: config.announcementEnabled,
-          minigames: config.minigamesEnabled,
-          environment: config.environmentEnabled,
         });
       } catch (err) {
         error('Error while saving server setup', err);
@@ -964,11 +960,7 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
         `<size="20">Server restart in <b><color="ffffbb">${5} seconds</></></>`,
       );
       await new Promise(resolve => setTimeout(resolve, 5000));
-      omegga.changeMap(omegga.currentMap);
-      await new Promise(resolve => setTimeout(resolve, 100));
-      if (omegga.started) await omegga.stop();
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      await omegga.start();
+      await omegga.restartServer();
     });
 
     // subscribe and unsubscribe to events

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -717,10 +717,8 @@ export default class Database extends EventEmitter {
         dailyHour: 2,
         dailyHourEnabled: false,
         announcementEnabled: true,
-        bricksEnabled: true,
-        minigamesEnabled: true,
-        environmentEnabled: true,
         playersEnabled: true,
+        saveWorld: true,
       });
     }
 

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -716,11 +716,17 @@ export default class Database extends EventEmitter {
         emptyUptimeEnabled: false,
         dailyHour: 2,
         dailyHourEnabled: false,
+        autoUpdateEnabled: true,
+        autoUpdateIntervalMins: 60,
         announcementEnabled: true,
         playersEnabled: true,
         saveWorld: true,
       });
     }
+
+    config.autoUpdateEnabled ??= true;
+    config.autoUpdateIntervalMins ??= 60;
+    config.saveWorld ??= true;
 
     return config;
   }
@@ -731,6 +737,10 @@ export default class Database extends EventEmitter {
       Math.max(1, Math.min(config.emptyUptime, 168)),
     );
     config.dailyHour = Math.round(Math.max(0, Math.min(config.dailyHour, 23)));
+    config.autoUpdateIntervalMins = Math.round(
+      Math.max(10, Math.min(config.autoUpdateIntervalMins ?? 60, Infinity)),
+    );
+    config.autoUpdateEnabled ??= true;
     await this.stores.server.update(
       { type: 'autoRestartConfig' },
       {

--- a/src/webserver/backend/metrics.ts
+++ b/src/webserver/backend/metrics.ts
@@ -92,9 +92,13 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
       Logger.logp('Stopping server for auto-update...');
       await omegga.stop();
       Logger.logp('Downloading update...');
-      steamcmdDownloadGame({
-        steambeta: omegga.config.server?.steambeta,
-      });
+      try {
+        steamcmdDownloadGame({
+          steambeta: omegga.config.server?.steambeta,
+        });
+      } catch (e) {
+        error('An error occurred while downloading the update:', e);
+      }
       Logger.logp('Starting server after update...');
       await omegga.start();
     } else {

--- a/src/webserver/backend/metrics.ts
+++ b/src/webserver/backend/metrics.ts
@@ -1,14 +1,14 @@
 import Logger from '@/logger';
-import { AutoRestartConfig, IServerStatus, OmeggaLike } from '@/plugin';
+import { AutoRestartConfig, IServerStatus } from '@/plugin';
 import soft from '@/softconfig';
-import type Webserver from './index';
-import { OmeggaSocketIo, IStoreAutoRestartConfig } from './types';
 import {
   clearLastSteamUpdateCheck,
   getLastSteamUpdateCheck,
   hasSteamUpdate,
   steamcmdDownloadGame,
 } from '@/updater/steam';
+import type Webserver from './index';
+import { IStoreAutoRestartConfig, OmeggaSocketIo } from './types';
 
 const error = (...args: any[]) => Logger.error(...args);
 let lastRestart = 0;
@@ -309,6 +309,11 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
     io
       .to('server')
       .emit('status', { started: false, starting: true, stopping: false }),
+  );
+  omegga.on('mapchange', () =>
+    io
+      .to('server')
+      .emit('status', { started: true, starting: false, stopping: false }),
   );
   omegga.on('server:stopped', () =>
     io

--- a/src/webserver/backend/metrics.ts
+++ b/src/webserver/backend/metrics.ts
@@ -31,10 +31,8 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
     lastRestart = Date.now();
     const iconfig: AutoRestartConfig = {
       players: config.playersEnabled,
-      bricks: config.bricksEnabled,
       announcement: config.announcementEnabled,
-      minigames: config.minigamesEnabled,
-      environment: config.environmentEnabled,
+      saveWorld: config.saveWorld,
     };
     omegga.emit('autorestart', iconfig);
     await sleep(1000);
@@ -74,7 +72,8 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
     omegga.once('mapchange', () => {
       omegga.restoreServer();
     });
-    omegga.changeMap(omegga.currentMap);
+
+    await omegga.restartServer();
   }
 
   async function checkAutoRestart(status: IServerStatus) {

--- a/src/webserver/backend/types.d.ts
+++ b/src/webserver/backend/types.d.ts
@@ -46,6 +46,8 @@ export interface IStoreAutoRestartConfig {
   emptyUptimeEnabled: boolean;
   dailyHour: number;
   dailyHourEnabled: boolean;
+  autoUpdateEnabled: boolean;
+  autoUpdateIntervalMins: number;
   announcementEnabled: boolean;
   playersEnabled: boolean;
   saveWorld: boolean;

--- a/src/webserver/backend/types.d.ts
+++ b/src/webserver/backend/types.d.ts
@@ -48,9 +48,7 @@ export interface IStoreAutoRestartConfig {
   dailyHourEnabled: boolean;
   announcementEnabled: boolean;
   playersEnabled: boolean;
-  bricksEnabled: boolean;
-  minigamesEnabled: boolean;
-  environmentEnabled: boolean;
+  saveWorld: boolean;
 }
 
 export interface IStoreChat {


### PR DESCRIPTION
Prereq: #50

- Replaces restart config: save bricks/environment/minigames with save world
- Adds `/restart` in terminal
- Makes restart load the default world
- Adds a `/world use <world>` command to set the default world for starutp and restart
- Adds `/update` in terminal
- Adds an update feature to the auto restart server settings (with an interval)
- Automatically check for steam updates on omegga startup

todo:
- [x] worlds view (with save, load, saveas, load revision)
- [x] fix saveWorld promise to actually confirm save finishes
- [x] set default world button in ui
- [x] save world button in server view