### PR TITLE
Fix install_steamcmd.sh package check in Arch

### DIFF
--- a/tools/install_steamcmd.sh
+++ b/tools/install_steamcmd.sh
@@ -38,7 +38,7 @@ pkg_manager="apt-get install"
 if [[ -f /etc/arch-release ]]; then
   lib32gcc_dep="lib32-gcc-libs"
   pkg_manager="pacman -S"
-  has_lib32gcc=$(dpkg -s lib32-gcc-libs >/dev/null 2>&1 && echo "yes" || echo "no")
+  has_lib32gcc=$(pacman -Q lib32-gcc-libs >/dev/null 2>&1 && echo "yes" || echo "no")
 fi
 
 # check if lib32gcc-s1 exists in debian/ubuntu


### PR DESCRIPTION
update use of `dpkg` for checking existing packages in Arch linux