### PR TITLE
fix(tools): install_steamcmd.sh arch dependency check

### DIFF
--- a/tools/install_steamcmd.sh
+++ b/tools/install_steamcmd.sh
@@ -34,15 +34,13 @@ has_lib32gcc="yes" # sorry anyone not running arch/debian
 lib32gcc_dep="lib32gcc-s1"
 pkg_manager="apt-get install"
 
-# check if lib32-gcc-libs is installed in arch linux
 if [[ -f /etc/arch-release ]]; then
+  # if lib32-gcc-libs is installed in arch linux
   lib32gcc_dep="lib32-gcc-libs"
   pkg_manager="pacman -S"
   has_lib32gcc=$(pacman -Q lib32-gcc-libs >/dev/null 2>&1 && echo "yes" || echo "no")
-fi
-
-# check if lib32gcc-s1 exists in debian/ubuntu
-if [[ -f /etc/debian_version ]] || [[ -f /etc/lsb-release ]]; then
+elif [[ -f /etc/debian_version ]] || [[ -f /etc/lsb-release ]]; then
+  # if lib32gcc-s1 exists in debian/ubuntu
   lib32gcc_dep="lib32gcc-s1"
   pkg_manager="apt-get install"
   has_lib32gcc=$(dpkg -s lib32gcc-s1 >/dev/null 2>&1 && echo "yes" || echo "no")


### PR DESCRIPTION
`/etc/lsb-release` exists on Arch, so the debian/ubuntu check will run even if the arch check succeeds.