### PR TITLE
feat(plugins): dep graph resolution

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "test:backend",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "label": "npm: test:backend",
+      "detail": "npm run test:backend"
+    }
+  ]
+}

--- a/src/omegga/plugin.test.ts
+++ b/src/omegga/plugin.test.ts
@@ -1,0 +1,105 @@
+import { MockPlugin } from '@/test/mockPlugin';
+import { mockOmegga } from '@/test/util';
+import { describe, expect, it, test } from 'vitest';
+import { PluginLoader } from './plugin';
+
+describe('PluginLoader.calculateLoadOrder', () => {
+  const omegga = mockOmegga();
+
+  it('sorts unconfigured plugins by name', () => {
+    const plugins = [
+      new MockPlugin('h', omegga),
+      new MockPlugin('g', omegga),
+      new MockPlugin('d', omegga),
+      new MockPlugin('f', omegga),
+      new MockPlugin('e', omegga),
+      new MockPlugin('c', omegga),
+      new MockPlugin('b', omegga),
+      new MockPlugin('a', omegga),
+    ];
+    const sorted = PluginLoader.calculateLoadOrder(plugins);
+
+    // expect sorted to be ordered by name
+    expect(sorted.map(p => p.getName())).toEqual(
+      plugins.map(p => p.getName()).sort(),
+    );
+  });
+
+  it('sorts unconfigured plugins by load priority', () => {
+    const plugins = [
+      new MockPlugin('a', omegga, { config: { loadPriority: 4 } }),
+      new MockPlugin('b', omegga, { config: { loadPriority: 3 } }),
+      new MockPlugin('c', omegga, { config: { loadPriority: 2 } }),
+      new MockPlugin('d', omegga, { config: { loadPriority: 1 } }),
+      new MockPlugin('e', omegga, { config: { loadPriority: 0 } }),
+      new MockPlugin('f', omegga, { config: { loadPriority: -1 } }),
+      new MockPlugin('g', omegga, { config: { loadPriority: -2 } }),
+      new MockPlugin('h', omegga, { config: { loadPriority: -3 } }),
+      new MockPlugin('i', omegga, { config: { loadPriority: -4 } }),
+    ];
+    const sorted = PluginLoader.calculateLoadOrder(plugins);
+
+    expect(sorted.map(p => p.getName())).toEqual(
+      plugins
+        .slice()
+        .sort(
+          // ascending sort (lower loadPriority loads first)
+          (a, b) => a.pluginConfig.loadPriority - b.pluginConfig.loadPriority,
+        )
+        .map(p => p.getName()),
+    );
+  });
+
+  it('orders with loadBefore', () => {
+    const plugins = [
+      new MockPlugin('a', omegga, {}),
+      new MockPlugin('b', omegga, { config: { loadBefore: ['a'] } }),
+      new MockPlugin('c', omegga, { config: { loadBefore: ['b'] } }),
+      new MockPlugin('d', omegga, { config: { loadBefore: ['c'] } }),
+      new MockPlugin('e', omegga, { config: { loadBefore: ['d'] } }),
+      new MockPlugin('f', omegga, { config: { loadBefore: ['e'] } }),
+      new MockPlugin('g', omegga, { config: { loadBefore: ['f'] } }),
+      new MockPlugin('h', omegga, { config: { loadBefore: ['g'] } }),
+    ];
+    const sorted = PluginLoader.calculateLoadOrder(plugins);
+
+    expect(sorted.map(p => p.getName())).toEqual([
+      'h',
+      'g',
+      'f',
+      'e',
+      'd',
+      'c',
+      'b',
+      'a',
+    ]);
+  });
+
+  it('orders with loadAfter', () => {
+    // reverse alphabetical order
+    const plugins = [
+      new MockPlugin('a', omegga, { config: { loadAfter: ['b'] } }),
+      new MockPlugin('b', omegga, { config: { loadAfter: ['c'] } }),
+      new MockPlugin('c', omegga, { config: { loadAfter: ['d'] } }),
+      new MockPlugin('d', omegga, { config: { loadAfter: ['e'] } }),
+      new MockPlugin('e', omegga, { config: { loadAfter: ['f'] } }),
+      new MockPlugin('f', omegga, { config: { loadAfter: ['g'] } }),
+      new MockPlugin('g', omegga, { config: { loadAfter: ['h'] } }),
+      new MockPlugin('h', omegga, { config: { loadAfter: ['i'] } }),
+      new MockPlugin('i', omegga, {}),
+    ];
+    const sorted = PluginLoader.calculateLoadOrder(plugins);
+
+    expect(sorted.map(p => p.getName())).toEqual([
+      'i',
+      'h',
+      'g',
+      'f',
+      'e',
+      'd',
+      'c',
+      'b',
+      'a',
+    ]);
+  });
+});

--- a/src/omegga/plugin.ts
+++ b/src/omegga/plugin.ts
@@ -324,7 +324,7 @@ export class PluginLoader {
     }
   }
 
-  calculateLoadOrder(unsortedPlugins: Plugin[]) {
+  static calculateLoadOrder(unsortedPlugins: Plugin[]) {
     if (!unsortedPlugins.length) {
       return [];
     }
@@ -464,7 +464,7 @@ export class PluginLoader {
       // remove plugins without formats
       .filter(p => p);
 
-    this.plugins = this.calculateLoadOrder(unsortedPlugins);
+    this.plugins = PluginLoader.calculateLoadOrder(unsortedPlugins);
 
     Logger.verbose('Finished scanning plugin directory');
     Logger.verbose(

--- a/src/test/mockPlugin.ts
+++ b/src/test/mockPlugin.ts
@@ -1,0 +1,70 @@
+import { IPluginDocumentation } from '@/plugin';
+import { IPluginJSON } from '@omegga/plugin';
+import { Plugin } from '@omegga/plugin/interface';
+import Omegga from '@omegga/server';
+import { EventEmitter } from 'node:stream';
+
+export class MockPlugin extends Plugin {
+  static canLoad(_pluginPath: string) {
+    return true;
+  }
+
+  static getFormat() {
+    return 'mock';
+  }
+
+  events: EventEmitter;
+  loaded = false;
+
+  constructor(
+    pluginPath: string,
+    omegga: Omegga,
+    {
+      docs = {},
+      config = {},
+    }: {
+      docs?: Partial<IPluginDocumentation>;
+      config?: Partial<IPluginJSON>;
+    } = {},
+  ) {
+    super(pluginPath, omegga);
+    this.documentation = {
+      name: pluginPath,
+      author: 'test',
+      commands: [],
+      config: {},
+      description: 'A mock plugin for testing',
+      ...docs,
+    };
+    this.pluginConfig = {
+      omeggaVersion: '*',
+      formatVersion: 1,
+      ...config,
+    };
+  }
+
+  emitPluginEvent(event: string, from: string, ...args: any[]) {
+    this.events.emit('emitPlugin', event, from, ...args);
+  }
+
+  getDocumentation(): IPluginDocumentation {
+    return this.documentation;
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  isCommand(cmd: string): boolean {
+    return this.documentation.commands.find(c => c.name === cmd) !== undefined;
+  }
+
+  async load() {
+    this.loaded = true;
+    return true;
+  }
+  async unload() {
+    this.loaded = false;
+    return true;
+  }
+}

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,0 +1,8 @@
+import Omegga from '@omegga/server';
+
+export const mockOmegga = () =>
+  new Omegga(
+    process.cwd(),
+    { server: { port: 7777 } },
+    { noauth: true, noweb: true, nodirs: true, noplugin: true },
+  );


### PR DESCRIPTION
This is to resolve parts of #75.

This is meant to fix the order of the loading by introducing new props in `plugin.json`. These props are `dependencies`, `loadPriority`, `loadBefore`, and `loadAfter`.

How it works:
- It creates a directed acyclic graph of the dependencies based on the `dependencies`, `loadBefore`, and `loadAfter` props.
- Does a topological sort on the plugins to separate them into groups where the order of loading matters.
- Inside of these sub-groups, the order of loading doesn't matter based on the dependencies, so they are sorted by `loadPriority`.
- If there are no load priorities, the groups are sorted alphabetically.

# Examples
Here's a couple examples to illustrate the ordering.
## No dependencies, No loadPriority, No loadBefore/After
Plugins:
- A
- B
- C
- D

Output:
`[A, B, C, D]`
## No dependencies, loadPriority, No loadBefore/After
Plugins:
- A
- B
- C (loadPriority 10)
- D

Output:
`[C, A, B, D]`
## No dependencies, loadPriority, loadBefore/After
Plugins:
- A
- B (loadBefore A)
- C (loadPriority 10)
- D

Output:
`[B, C, A, D]`
## Dependencies, loadPriority, loadBefore/After
Plugins:
- A (load priority -100000)
- B (depends on A)
- C (depends on A,B)
- D (depends on C)
- E (depends on C, load priority 10000)
- aF (depends on C)

Output:
`[A, B, C, E, aF, D]`

# Further questions
- Should this load order also apply when manually executing `/plugin reload` or `/plugins load`?

# Notes:
- I had initially done it a simpler way described by @Meshiest but that was proving to be complicated to implement all the properties with so I just went with a topological sort.
- Any cycles with `loadBefore/After` or `dependencies` will make the load fail and it will log it.