### PR TITLE
feat: auto restart, steamcmd fixes, unsafe plugin interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,8 @@ Cleanup is important as code can still be running after the plugin is unloaded r
 
 Register custom `/commands` by returning `{registeredCommands: ['foo', 'bar']}` (registers command `/foo` and `/bar`) in the `async init()` method.
 
+By defining an `async pluginEvent(event, from, ...args)` method in your plugin class, you can respond to events from other plugins, where `from` is the name of the other plugin, `event` is the name of the custom event, and `args` is an array of any passed arguments.
+
 ### Globals
 
 - `OMEGGA_UTIL` - access to the `src/util/index.js` module
@@ -769,6 +771,13 @@ class PluginName {
     this.omegga
       .removeAllListeners('chatcmd:ping')
       .removeAllListeners('chatcmd:pos');
+  }
+
+  // optional: respond to events from other plugins
+  async pluginEvent(event, from, ...args) {
+    if (event === 'greeting') {
+      return `Hello from ${from}!`;
+    }
   }
 }
 

--- a/bin/omegga
+++ b/bin/omegga
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps
+#!/usr/bin/env -S node --enable-source-maps --disable-warning=DEP0040
 
 require('../dist/main.js');

--- a/frontend/src/views/server/index.tsx
+++ b/frontend/src/views/server/index.tsx
@@ -84,6 +84,7 @@ export const ServerView = () => {
       autoUpdateIntervalMins: Math.round(
         Math.max(10, Math.min(config.autoUpdateIntervalMins ?? 60, Infinity)),
       ),
+      crashRestartEnabled: config.crashRestartEnabled ?? true,
     } satisfies IStoreAutoRestartConfig;
     rpcNotify('server.autorestart.set', blob);
   }, [config]);
@@ -217,6 +218,19 @@ export const ServerView = () => {
           </NavBar>
           {config && (
             <div className="inputs-list">
+              <div
+                className="inputs-item"
+                data-tooltip="When enabled, automatically restarts the server if the game engine crashes"
+              >
+                <label>Restart on Crash</label>
+                <div className="inputs">
+                  <Toggle
+                    tooltip="Enabled"
+                    value={config.crashRestartEnabled ?? true}
+                    onChange={changeConfig('crashRestartEnabled')}
+                  />
+                </div>
+              </div>
               <div
                 className="inputs-item"
                 data-tooltip="When enabled on servers setup with SteamCMD, automatically updates the server when a new version is available"

--- a/src/omegga/plugin/plugin_node_unsafe.ts
+++ b/src/omegga/plugin/plugin_node_unsafe.ts
@@ -158,6 +158,13 @@ export default class NodePlugin extends Plugin {
     }
   }
 
+  // forward plugin events to the loaded plugin instance
+  async emitPlugin(ev: string, from: string, args: any[]) {
+    if (typeof this.loadedPlugin?.pluginEvent === 'function') {
+      return await this.loadedPlugin.pluginEvent(ev, from, ...args);
+    }
+  }
+
   // disrequire all that match plugin path in require.cache
   disrequireAll() {
     // get all files in plugin directory from require cache

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -69,6 +69,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   started = false;
   starting = false;
   stopping = false;
+  crashDetected = false;
   currentMap: string;
 
   getServerStatus: () => Promise<IServerStatus>;
@@ -178,6 +179,22 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       this.restoreServer();
     });
 
+    // detect engine crash from stderr or stdout
+    const crashHandler = (line: string) => {
+      if (
+        !this.crashDetected &&
+        (/Engine crash handling finished; re-raising signal \d+ for the default handler\. Good bye\./.test(
+          line,
+        ) ||
+          /LogCore: === Critical error: ===/.test(line))
+      ) {
+        Logger.error('Engine crash detected!');
+        this.crashDetected = true;
+      }
+    };
+    this.on('err', crashHandler);
+    this.on('line', crashHandler);
+
     // when brickadia exits, stop omegga
     this.on('exit', () => {
       this.stop();
@@ -185,8 +202,34 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     // when the process closes, emit the exit signal and stop
     this.on('closed', () => {
+      // capture crash state before 'exit' handler triggers stop()
+      const wasCrash = this.crashDetected;
+      this.crashDetected = false;
       if (this.started) this.emit('exit');
-      if (!this.stopping) this.stop();
+      const doRestart = async () => {
+        if (!wasCrash) return;
+        try {
+          const config =
+            await this.webserver?.database?.getAutoRestartConfig();
+          if (config?.crashRestartEnabled) {
+            Logger.logp('Restarting server after crash...');
+            this.webserver?.database?.addChatLog(
+              'server',
+              {},
+              'Server crashed, restarting...',
+            );
+            await this.start();
+          }
+        } catch (err) {
+          Logger.error('Error restarting after crash', err);
+        }
+      };
+      if (!this.stopping) {
+        this.stop().then(doRestart);
+      } else {
+        // stop() already in progress from 'exit' handler — wait for it to finish
+        this.once('server:stopped', () => doRestart());
+      }
     });
 
     // detect when a missing command is sent

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -209,8 +209,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       const doRestart = async () => {
         if (!wasCrash) return;
         try {
-          const config =
-            await this.webserver?.database?.getAutoRestartConfig();
+          const config = await this.webserver?.database?.getAutoRestartConfig();
           if (config?.crashRestartEnabled) {
             Logger.logp('Restarting server after crash...');
             this.webserver?.database?.addChatLog(

--- a/src/omegga/wrapper.ts
+++ b/src/omegga/wrapper.ts
@@ -41,6 +41,7 @@ class OmeggaWrapper extends EventEmitter {
     this.logWrangler = new LogWrangler(this as unknown as Omegga);
     this.#server.on('line', this.logWrangler.callback);
     this.#server.on('line', (line: string) => this.emit('line', line));
+    this.#server.on('err', (line: string) => this.emit('err', line));
     this.#server.on('closed', () => this.emit('closed'));
 
     this.addMatcher = this.logWrangler.addMatcher;

--- a/src/updater/steam.ts
+++ b/src/updater/steam.ts
@@ -5,6 +5,39 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import acfParser from 'steam-acf2json';
 
+// Steam EAppState flags (bitmask)
+const STEAM_APP_STATES: Record<number, string> = {
+  0x1: 'Uninstalled',
+  0x2: 'Update Required',
+  0x4: 'Fully Installed',
+  0x8: 'Encrypted',
+  0x10: 'Locked',
+  0x20: 'Files Missing',
+  0x40: 'App Running',
+  0x80: 'Files Corrupt',
+  0x100: 'Update Running',
+  0x200: 'Update Paused',
+  0x400: 'Update Started',
+  0x800: 'Uninstalling',
+  0x1000: 'Backup Running',
+  0x10000: 'Reconfiguring',
+  0x20000: 'Validating',
+  0x40000: 'Adding Files',
+  0x80000: 'Preallocating',
+  0x100000: 'Downloading',
+  0x200000: 'Staging',
+  0x400000: 'Committing',
+  0x800000: 'Update Stopping',
+};
+
+function decodeAppState(state: number): string[] {
+  const flags: string[] = [];
+  for (const [bit, name] of Object.entries(STEAM_APP_STATES)) {
+    if (state & Number(bit)) flags.push(name);
+  }
+  return flags;
+}
+
 export function steamcmdDownloadSelf() {
   execSync(path.join(__dirname, '../../tools/install_steamcmd.sh'), {
     stdio: 'inherit',
@@ -40,7 +73,31 @@ export function steamcmdDownloadGame({
     '+quit',
   ].filter(Boolean);
 
-  execSync(`${STEAMCMD_PATH} ${args.join(' ')}`, { stdio: 'inherit' });
+  try {
+    execSync(`${STEAMCMD_PATH} ${args.join(' ')}`, { stdio: 'inherit' });
+  } catch (err) {
+    if (err instanceof Error && err.message) {
+      // Log decoded app state if present
+      const stateMatch = err.message.match(
+        /state is (0x[0-9A-Fa-f]+) after update job/,
+      );
+      if (stateMatch) {
+        const state = parseInt(stateMatch[1], 16);
+        const flags = decodeAppState(state);
+        Logger.error(
+          `Steam app state ${stateMatch[1]} (${state}):`,
+          flags.length > 0 ? flags.join(', ') : 'Unknown',
+        );
+      }
+
+      // Redact credentials from error messages
+      err.message = err.message
+        .replace(/\+login\s+"[^"]*"\s+"[^"]*"/, '+login <REDACTED>')
+        .replace(/\+login\s+(\S+)\s+\S+/, '+login $1 <REDACTED>')
+        .replace(/-betapassword\s+\S+/, '-betapassword <REDACTED>');
+    }
+    throw err;
+  }
 }
 
 export type SteamInfo = {

--- a/src/webserver/backend/api.ts
+++ b/src/webserver/backend/api.ts
@@ -957,6 +957,7 @@ export default function (server: Webserver, io: OmeggaSocketIo) {
       saveWorld: 'boolean',
       autoUpdateEnabled: 'boolean',
       autoUpdateIntervalMins: 'number',
+      crashRestartEnabled: 'boolean',
     };
 
     rpc.addMethod(

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -741,12 +741,14 @@ export default class Database extends EventEmitter {
         announcementEnabled: true,
         playersEnabled: true,
         saveWorld: true,
+        crashRestartEnabled: true,
       });
     }
 
     config.autoUpdateEnabled ??= true;
     config.autoUpdateIntervalMins ??= 60;
     config.saveWorld ??= true;
+    config.crashRestartEnabled ??= true;
 
     return config;
   }

--- a/src/webserver/backend/types.d.ts
+++ b/src/webserver/backend/types.d.ts
@@ -53,6 +53,7 @@ export interface IStoreAutoRestartConfig {
   announcementEnabled: boolean;
   playersEnabled: boolean;
   saveWorld: boolean;
+  crashRestartEnabled: boolean;
 }
 
 export interface IStoreChat {


### PR DESCRIPTION
- add crash auto-restart: detect engine crashes via stderr/stdout and automatically restart, with a new "Restart on Crash" toggle in the web UI (default Enabled)
- improve SteamCMD error handling: decode `EAppState` flags on update failure and redact credentials from error messages
- add pluginEvents to unsafe node plugins
- forward game server stderr as `err` events on the wrapper (used by crash detection)
- suppress Node.js `DEP0040` deprecation warning in `bin/omegga`
