### PR TITLE
feat(users): 1.6.0 - Permissions, 2FA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Add owner-only user disable and delete actions to the web UI (hidden in single-user mode)
 
+## 1.6.0 - TBD
+
+- Add granular permission system with scopes, domains, and role-based access control
+- Web UI: user inspector with permission editor, default permissions editor, user disable/delete actions
+- Web UI: responsive tablet layout for players, plugins, worlds, and server views
+- Self-service password change for all authenticated users
+- Privilege escalation protection - non-owners cannot grant permissions they don't have
+
+
 ## 1.5.4 - 2026-05-18
 
 - Fix vm2 error with Player.getRoles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Latest
 
-Add new changes here as they are implemented
+- Add owner-only user disable and delete actions to the web UI (hidden in single-user mode)
 
 ## 1.5.4 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@
 
 - Future features go here
 
-## 1.6.0 - TBD
+## 1.6.0 - 2026-05-24
 
 - Add owner-only user disable and delete actions to the web UI
 - Add granular permission system with scopes and domains for access control
 - Add TOTP two-factor authentication, WebAuthn passkeys (passwordless), and recovery codes
 - Add self-service account management (password change, MFA setup) for all users in the Account view
 - Add `/user passwd` and `/user resetmfa` terminal commands
-- Web UI: scope-aware enforcement -- buttons, views, and sidenav items hidden based on user permissions
+- Web UI: scope-aware enforcement -- buttons, views, queries, and subscriptions gated by user permissions
 - Web UI: user inspector with permission editor, default permissions, user disable/delete
 - Web UI: slightly improved responsive tablet layout for all views
+- Deleted or banned users are immediately disconnected from active sessions and live subscriptions
 
 
 ## 1.5.4 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,18 @@
 
 ## Latest
 
-- Add owner-only user disable and delete actions to the web UI (hidden in single-user mode)
+- Future features go here
 
 ## 1.6.0 - TBD
 
-- Add granular permission system with scopes, domains, and role-based access control
-- Web UI: user inspector with permission editor, default permissions editor, user disable/delete actions
-- Web UI: responsive tablet layout for players, plugins, worlds, and server views
-- Self-service password change for all authenticated users
-- Privilege escalation protection - non-owners cannot grant permissions they don't have
+- Add owner-only user disable and delete actions to the web UI
+- Add granular permission system with scopes and domains for access control
+- Add TOTP two-factor authentication, WebAuthn passkeys (passwordless), and recovery codes
+- Add self-service account management (password change, MFA setup) for all users in the Account view
+- Add `/user passwd` and `/user resetmfa` terminal commands
+- Web UI: scope-aware enforcement -- buttons, views, and sidenav items hidden based on user permissions
+- Web UI: user inspector with permission editor, default permissions, user disable/delete
+- Web UI: slightly improved responsive tablet layout for all views
 
 
 ## 1.5.4 - 2026-05-18

--- a/bin/omegga
+++ b/bin/omegga
@@ -1,3 +1,3 @@
-#!/usr/bin/env -S node --enable-source-maps --disable-warning=DEP0040
+#!/usr/bin/env -S node --enable-source-maps --disable-warning=DEP0040 --trace-warnings
 
 require('../dist/main.js');

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -1,0 +1,166 @@
+# Web UI Permission System
+
+The web UI uses a hierarchical, purely additive permission model. Permissions can only grant access, never deny it.
+
+## Data Model
+
+Each user has a `PermissionSet`:
+
+```ts
+interface PermissionSet {
+  root: 'all' | 'read' | 'off';
+  domains: Partial<Record<Domain, 'all' | 'read'>>;
+  scopes: Partial<Record<Scope, boolean>>;
+}
+```
+
+A server-wide **default** `PermissionSet` serves as a fallback for all users.
+
+## Resolution
+
+When checking whether a user has a specific scope, the resolver walks four levels in order. The first level that produces a definite answer wins.
+
+```
+1. Owner bypass    - isOwner grants everything
+2. Root level      - 'all' grants everything; 'read' grants read-only scopes; 'off' falls through
+3. Domain level    - 'all' grants all scopes in that domain; 'read' grants read-only scopes; absent falls through
+4. Scope level     - true grants; false denies; absent falls through to defaults
+5. Default perms   - same root/domain/scope resolution, but with no further fallback
+6. Not granted     - false
+```
+
+The `readOnly` flag on each scope definition determines whether "Read Only" mode at root or domain level grants that scope.
+
+## Levels
+
+### Root
+
+| Value | UI Label | Behavior |
+|-------|----------|----------|
+| `all` | All | Grants every scope |
+| `read` | Read Only | Grants only scopes marked `readOnly: true` |
+| `off` | Manual | Falls through to domain and scope checks |
+
+### Domain
+
+| Value | UI Label | Behavior |
+|-------|----------|----------|
+| `all` | All | Grants every scope in this domain |
+| `read` | Read Only | Grants only `readOnly` scopes in this domain |
+| *(absent)* | Manual | Falls through to individual scope toggles |
+
+Domains are purely additive. Setting a domain to "Manual" removes it from the `domains` map rather than storing a deny value.
+
+### Scope
+
+Individual boolean toggles. `true` grants, `false` denies, absent falls through to defaults.
+
+## Domains and Scopes
+
+Each scope belongs to exactly one domain and is either read-only (R) or read-write (W).
+
+### Chat
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `chat.send` | W | Send chat messages |
+| `chat.recent` | R | View recent chat messages |
+| `chat.history` | R | View chat history |
+| `chat.calendar` | R | View chat calendar |
+
+### Player
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `player.list` | R | View player list |
+| `player.get` | R | View player details |
+| `player.ban` | W | Ban players |
+| `player.kick` | W | Kick players |
+| `player.unban` | W | Unban players |
+| `player.clearBricks` | W | Clear player bricks |
+
+### Plugin
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `plugin.list` | R | View plugin list |
+| `plugin.get` | R | View plugin details |
+| `plugin.config` | W | Change plugin configuration |
+| `plugin.load` | W | Load plugins |
+| `plugin.unload` | W | Unload plugins |
+| `plugin.toggle` | W | Enable/disable plugins |
+| `plugin.reloadAll` | W | Reload all plugins |
+
+### Server
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `server.status` | R | View server status, receive live status updates and heartbeat |
+| `server.start` | W | Start the server |
+| `server.stop` | W | Stop the server |
+| `server.restart` | W | Restart the server |
+| `server.update.check` | W | Check for server updates (runs SteamCMD) |
+| `server.update.run` | W | Update the server |
+| `server.autorestart.get` | R | View auto-restart config |
+| `server.autorestart.set` | W | Change auto-restart config |
+| `server.utilization` | R | View and receive live CPU, memory, and disk usage |
+
+### User
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `user.list` | R | View web UI users |
+| `user.create` | W | Create web UI users |
+| `user.passwd` | W | Change other users' passwords |
+| `user.ban` | W | Disable/enable web UI users |
+| `user.delete` | W | Delete web UI users |
+| `user.permissions` | W | Manage user and default permissions |
+
+### World
+| Scope | R/W | Description |
+|-------|-----|-------------|
+| `world.list` | R | View world list |
+| `world.active` | R | View active world |
+| `world.next` | R | View next world |
+| `world.revisions` | R | View world revisions |
+| `world.meta` | R | View world metadata |
+| `world.load` | W | Load worlds |
+| `world.use` | W | Set default world |
+| `world.save` | W | Save worlds |
+| `world.create` | W | Create worlds |
+
+## Self-Service
+
+All authenticated users can access the Users page regardless of permissions. Users without `user.list` see a self-service view showing only their own account, where they can change their own password.
+
+The `user.self` endpoint (scoped to `session.info`) returns the current user's data without requiring `user.list`. The `user.passwd` endpoint allows any user to change their own password; changing another user's password requires the `user.passwd` scope.
+
+## Enforcement
+
+### Backend
+
+Every tRPC endpoint is wrapped with `protectedProcedure(scope)`, which runs `requireScope` middleware. The middleware:
+
+1. Rejects unauthenticated requests (`UNAUTHORIZED`)
+2. Allows owners unconditionally
+3. Resolves the scope against the user's permissions + server defaults
+4. Rejects with `FORBIDDEN` if not granted
+
+Subscription endpoints (like `server.onStatus`, `chat.onMessage`) share the scope of their corresponding query endpoint rather than having separate scopes.
+
+### Frontend
+
+On login, the session response includes `resolvedScopes` -- a flat `Record<string, boolean>` with every scope pre-resolved. The frontend stores this in a nanostore (`$resolvedScopes`).
+
+- `useHasScope(...scopes)` -- returns true if the user has all specified scopes
+- `useHasAnyScope(domain?)` -- returns true if the user has any scope in the domain
+- `useRequireDomain(domain)` -- redirects to `/` if the user has no scopes in the domain
+
+Sidenav links are gated by `useHasAnyScope(domain)`, except Users which is always visible for self-service access. Views that require a domain redirect to the dashboard if the user has no scopes in that domain. Individual buttons and controls are conditionally rendered based on specific scopes.
+
+The backend remains the source of truth -- frontend checks are for UX only.
+
+## Privilege Escalation Prevention
+
+When a non-owner user edits another user's permissions, the backend checks that the editor is not granting scopes they don't have themselves. The mutation resolves all scopes in the proposed `PermissionSet` against defaults and rejects any scope the editor lacks.
+
+## Storage
+
+User permissions are stored in the `users` NeDB store as part of each user document. Default permissions are stored in the `server` NeDB store as a `{ type: 'defaultPermissions' }` document.
+
+New users are created with `EMPTY_PERMISSIONS` (`root: 'off', domains: {}, scopes: {}`), which means all access is determined by server defaults until explicitly configured.

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -24,7 +24,7 @@ When checking whether a user has a specific scope, the resolver walks four level
 1. Owner bypass    - isOwner grants everything
 2. Root level      - 'all' grants everything; 'read' grants read-only scopes; 'off' falls through
 3. Domain level    - 'all' grants all scopes in that domain; 'read' grants read-only scopes; absent falls through
-4. Scope level     - true grants; false denies; absent falls through to defaults
+4. Scope level     - true grants; absent falls through to defaults
 5. Default perms   - same root/domain/scope resolution, but with no further fallback
 6. Not granted     - false
 ```
@@ -53,7 +53,7 @@ Domains are purely additive. Setting a domain to "Manual" removes it from the `d
 
 ### Scope
 
-Individual boolean toggles. `true` grants, `false` denies, absent falls through to defaults.
+Permissions are purely additive. `true` grants the scope, absent (or toggled off) falls through to defaults. There is no way to explicitly deny a scope -- toggling a scope off simply removes the user-level override so the default applies.
 
 ## Domains and Scopes
 

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -62,73 +62,75 @@ Each scope belongs to exactly one domain and is either read-only (R) or read-wri
 ### Chat
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `chat.send` | W | Send chat messages |
-| `chat.recent` | R | View recent chat messages |
-| `chat.history` | R | View chat history |
-| `chat.calendar` | R | View chat calendar |
+| `chat.send` | W | Send messages in the dashboard chat widget |
+| `chat.recent` | R | View recent chat on the dashboard |
+| `chat.history` | R | Browse past chat logs in the history view |
+| `chat.calendar` | R | Navigate chat by date in the history view |
 
 ### Player
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `player.list` | R | View player list |
-| `player.get` | R | View player details |
-| `player.ban` | W | Ban players |
-| `player.kick` | W | Kick players |
-| `player.unban` | W | Unban players |
-| `player.clearBricks` | W | Clear player bricks |
+| `player.list` | R | View the player list in the players view |
+| `player.get` | R | Inspect player details and history |
+| `player.ban` | W | Ban players from the player inspector |
+| `player.kick` | W | Kick players from the player inspector |
+| `player.unban` | W | Unban players from the player inspector |
+| `player.clearBricks` | W | Clear a player's bricks from the player inspector |
 
 ### Plugin
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `plugin.list` | R | View plugin list |
-| `plugin.get` | R | View plugin details |
-| `plugin.config` | W | Change plugin configuration |
-| `plugin.load` | W | Load plugins |
-| `plugin.unload` | W | Unload plugins |
-| `plugin.toggle` | W | Enable/disable plugins |
-| `plugin.reloadAll` | W | Reload all plugins |
+| `plugin.list` | R | View installed plugins in the plugins view |
+| `plugin.get` | R | Inspect plugin details and configuration |
+| `plugin.config` | W | Edit plugin settings in the plugin inspector |
+| `plugin.load` | W | Load plugins from the plugin inspector |
+| `plugin.unload` | W | Unload plugins from the plugin inspector |
+| `plugin.toggle` | W | Enable or disable plugins in the plugins view |
+| `plugin.reloadAll` | W | Reload all plugins from the plugins view |
 
 ### Server
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `server.status` | R | View server status, receive live status updates and heartbeat |
-| `server.start` | W | Start the server |
-| `server.stop` | W | Stop the server |
-| `server.restart` | W | Restart the server |
-| `server.update.check` | W | Check for server updates (runs SteamCMD) |
-| `server.update.run` | W | Update the server |
-| `server.autorestart.get` | R | View auto-restart config |
-| `server.autorestart.set` | W | Change auto-restart config |
-| `server.utilization` | R | View and receive live CPU, memory, and disk usage |
+| `server.status` | R | View server status on the dashboard and server view |
+| `server.start` | W | Start the server from the server view |
+| `server.stop` | W | Stop the server from the server view |
+| `server.restart` | W | Restart the server from the server view |
+| `server.update.check` | W | Check for server updates in the server view (runs SteamCMD) |
+| `server.update.run` | W | Run server updates from the server view |
+| `server.autorestart.get` | R | View auto-restart settings in the server view |
+| `server.autorestart.set` | W | Change auto-restart settings in the server view |
+| `server.utilization` | R | View CPU, memory, and disk usage on the dashboard |
 
 ### User
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `user.list` | R | View web UI users |
-| `user.create` | W | Create web UI users |
-| `user.passwd` | W | Change other users' passwords |
-| `user.ban` | W | Disable/enable web UI users |
-| `user.delete` | W | Delete web UI users |
-| `user.permissions` | W | Manage user and default permissions |
+| `user.list` | R | View web UI user accounts in the users view |
+| `user.create` | W | Create new user accounts in the users view |
+| `user.passwd` | W | Change other users' passwords in the user inspector |
+| `user.ban` | W | Disable or re-enable users in the user inspector |
+| `user.delete` | W | Permanently delete user accounts |
+| `user.permissions` | W | Edit user and default permissions in the users view |
+| `user.readMfa` | R | View MFA status of other users in the user inspector |
+| `user.resetMfa` | W | Reset MFA for other users in the user inspector |
 
 ### World
 | Scope | R/W | Description |
 |-------|-----|-------------|
-| `world.list` | R | View world list |
-| `world.active` | R | View active world |
-| `world.next` | R | View next world |
-| `world.revisions` | R | View world revisions |
-| `world.meta` | R | View world metadata |
-| `world.load` | W | Load worlds |
-| `world.use` | W | Set default world |
-| `world.save` | W | Save worlds |
-| `world.create` | W | Create worlds |
+| `world.list` | R | View available worlds in the worlds view |
+| `world.active` | R | See which world is currently loaded |
+| `world.next` | R | See which world will load next |
+| `world.revisions` | R | View world save revisions in the world inspector |
+| `world.meta` | R | View world metadata in the world inspector |
+| `world.load` | W | Load worlds from the world inspector |
+| `world.use` | W | Set the default world in the worlds view |
+| `world.save` | W | Save the current world from the worlds or server view |
+| `world.create` | W | Create new worlds in the worlds view |
 
 ## Self-Service
 
-All authenticated users can access the Users page regardless of permissions. Users without `user.list` see a self-service view showing only their own account, where they can change their own password.
+All authenticated users can access the `/account` page regardless of permissions. This page shows the user's own account info, MFA management (TOTP, passkeys, recovery codes), and password change.
 
-The `user.self` endpoint (scoped to `session.info`) returns the current user's data without requiring `user.list`. The `user.passwd` endpoint allows any user to change their own password; changing another user's password requires the `user.passwd` scope.
+The `user.self` endpoint (scoped to `session.info`) returns the current user's data without requiring `user.list`. The `user.passwd` endpoint allows any user to change their own password (requires current password); changing another user's password requires the `user.passwd` scope. MFA management endpoints (`mfa.*`) are scoped to `session.info` and require password verification for sensitive operations (TOTP setup/disable, passkey removal, recovery code generation).
 
 ## Enforcement
 
@@ -148,10 +150,35 @@ Subscription endpoints (like `server.onStatus`, `chat.onMessage`) share the scop
 On login, the session response includes `resolvedScopes` -- a flat `Record<string, boolean>` with every scope pre-resolved. The frontend stores this in a nanostore (`$resolvedScopes`).
 
 - `useHasScope(...scopes)` -- returns true if the user has all specified scopes
-- `useHasAnyScope(domain?)` -- returns true if the user has any scope in the domain
-- `useRequireDomain(domain)` -- redirects to `/` if the user has no scopes in the domain
+- `useHasAnyScope(...scopes)` -- returns true if the user has any of the specified scopes
+- `useRequireScope(scope)` -- redirects to `/` if the user lacks the scope
 
-Sidenav links are gated by `useHasAnyScope(domain)`, except Users which is always visible for self-service access. Views that require a domain redirect to the dashboard if the user has no scopes in that domain. Individual buttons and controls are conditionally rendered based on specific scopes.
+#### Sidenav Visibility
+
+Each sidenav link is gated by a specific scope:
+
+| Link | Required Scope | Always Visible |
+|------|---------------|----------------|
+| Dashboard | -- | Yes |
+| Worlds | `world.list` | No |
+| History | `chat.history` | No |
+| Plugins | `plugin.list` | No |
+| Players | `player.list` | No |
+| Server | `server.status` | No |
+| Users | `user.list` | No |
+| Account | -- | Yes |
+
+#### View Access
+
+Each view redirects to the dashboard if the user lacks its required scope:
+- Worlds requires `world.list`
+- History requires `chat.history`
+- Plugins requires `plugin.list`
+- Players requires `player.list`
+- Server requires `server.status`
+- Users requires `user.list`
+
+Within a view, individual buttons and controls are conditionally rendered based on their specific scopes. Admin actions in the user inspector (change password, disable, delete, reset MFA) are shown in an actions widget gated by their respective scopes.
 
 The backend remains the source of truth -- frontend checks are for UX only.
 

--- a/frontend/src/SessionInit.tsx
+++ b/frontend/src/SessionInit.tsx
@@ -1,3 +1,4 @@
+import { TRPCClientError } from '@trpc/client';
 import { useEffect } from 'react';
 import { $rpcConnected, $rpcDisconnected } from './stores/connected';
 import {
@@ -11,7 +12,7 @@ import { $version } from './stores/version';
 import { trpc } from './trpc';
 
 export const SessionInit = () => {
-  const { data, status } = trpc.session.info.useQuery();
+  const { data, status, error } = trpc.session.info.useQuery();
 
   useEffect(() => {
     if (status === 'success' && data) {
@@ -26,6 +27,12 @@ export const SessionInit = () => {
     } else if (status === 'error') {
       $rpcConnected.set(false);
       $rpcDisconnected.set(true);
+      if (
+        error instanceof TRPCClientError &&
+        error.data?.code === 'UNAUTHORIZED'
+      ) {
+        location.reload();
+      }
     }
   }, [data, status]);
 

--- a/frontend/src/SessionInit.tsx
+++ b/frontend/src/SessionInit.tsx
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
-import { trpc } from './trpc';
-import { $omeggaData, $roles, $showLogout, $user } from './stores/user';
-import { $version } from './stores/version';
 import { $rpcConnected, $rpcDisconnected } from './stores/connected';
+import {
+  $omeggaData,
+  $resolvedScopes,
+  $roles,
+  $showLogout,
+  $user,
+} from './stores/user';
+import { $version } from './stores/version';
+import { trpc } from './trpc';
 
 export const SessionInit = () => {
   const { data, status } = trpc.session.info.useQuery();
@@ -13,6 +19,7 @@ export const SessionInit = () => {
       $version.set(data.version);
       $user.set(data.user);
       $roles.set(data.roles);
+      $resolvedScopes.set(data.user.resolvedScopes ?? {});
       $showLogout.set(data.canLogOut);
       $rpcConnected.set(true);
       $rpcDisconnected.set(false);

--- a/frontend/src/_index.scss
+++ b/frontend/src/_index.scss
@@ -1,5 +1,6 @@
 @use 'css/theme';
 @use 'css/mixins';
+@use 'css/style';
 @use 'components';
 @use 'views';
 @use 'widgets';

--- a/frontend/src/auth/index.tsx
+++ b/frontend/src/auth/index.tsx
@@ -1,4 +1,10 @@
-import { IconArrowRight, IconLockOpen } from '@tabler/icons-react';
+import {
+  IconArrowRight,
+  IconFingerprint,
+  IconKey,
+  IconLockOpen,
+  IconShieldCheck,
+} from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import turkeyImage from '../../assets/img/turkey.webp';
@@ -11,13 +17,24 @@ import { Loader } from '../components/loader';
 import { Modal } from '../components/modal';
 import { PopoutContent } from '../components/popout';
 
+type AuthPhase = 'login' | 'mfa-totp';
+
+const canWebAuthn =
+  typeof window !== 'undefined' &&
+  !!window.PublicKeyCredential &&
+  (location.protocol === 'https:' || location.hostname === 'localhost');
+
 const Auth = () => {
   const [loading, setLoading] = useState(true);
   const [firstLoad, setFirstLoad] = useState(true);
+  const [phase, setPhase] = useState<AuthPhase>('login');
+  const [error, setError] = useState('');
 
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [totpCode, setTotpCode] = useState('');
+  const [useRecovery, setUseRecovery] = useState(false);
 
   useEffect(() => {
     fetch('/api/v1/first')
@@ -30,24 +47,82 @@ const Auth = () => {
 
   const tryAuth = useCallback(async (username: string, password: string) => {
     setLoading(true);
+    setError('');
     try {
       const res = await fetch('/api/v1/auth', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),
       });
       const data = await res.json();
       if (res.status === 200) {
+        if (data.mfaRequired) {
+          setPhase('mfa-totp');
+          setLoading(false);
+        } else {
+          location.reload();
+        }
+      } else {
+        setError(data.message || 'Authentication failed');
+        setLoading(false);
+      }
+    } catch {
+      setError('Connection failed');
+      setLoading(false);
+    }
+  }, []);
+
+  const submitTotp = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/v1/auth/mfa/totp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: totpCode }),
+      });
+      if (res.status === 200) {
         location.reload();
       } else {
-        console.error(data.message);
+        const data = await res.json();
+        setError(data.message || 'Invalid code');
+        setLoading(false);
       }
-    } catch (error) {
-      console.error('Authentication failed:', error);
+    } catch {
+      setError('Connection failed');
+      setLoading(false);
     }
-    setLoading(false);
+  }, [totpCode]);
+
+  const tryPasskey = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const optRes = await fetch('/api/v1/auth/webauthn/options');
+      const options = await optRes.json();
+
+      const { startAuthentication } = await import('@simplewebauthn/browser');
+      const credential = await startAuthentication({ optionsJSON: options });
+
+      const verifyRes = await fetch('/api/v1/auth/webauthn/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ credential }),
+      });
+      if (verifyRes.status === 200) {
+        location.reload();
+      } else {
+        setError('Passkey verification failed');
+        setLoading(false);
+      }
+    } catch (e: any) {
+      if (e?.name === 'NotAllowedError') {
+        setLoading(false);
+        return;
+      }
+      setError('Passkey authentication failed');
+      setLoading(false);
+    }
   }, []);
 
   const authBlank = username.length === 0 && password.length === 0;
@@ -66,68 +141,131 @@ const Auth = () => {
         </div>
       </Background>
       <Modal visible={!loading}>
-        <Header attached>Brickadia Server Login</Header>
-        <PopoutContent>
-          <p>Welcome to the Omegga Web UI.</p>
-          {firstLoad && (
-            <p>
-              Enter credentials for an Admin user. You can also skip this step
-              if you don't want to use a password.
-            </p>
-          )}
-        </PopoutContent>
-        <div className="popout-inputs">
-          <Input
-            placeholder="Username"
-            type="text"
-            value={username}
-            onChange={setUsername}
-          />
-          <Input
-            placeholder="Password"
-            type="password"
-            value={password}
-            onChange={setPassword}
-          />
-          {firstLoad && (
-            <Input
-              placeholder="Confirm Password"
-              type="password"
-              value={confirm}
-              onChange={setConfirm}
-            />
-          )}
-        </div>
-        <Footer attached>
-          {firstLoad && (
-            <Button
-              main
-              disabled={!authOk || confirm !== password}
-              onClick={() => tryAuth(username, password)}
-            >
-              <IconArrowRight /> Create
-            </Button>
-          )}
-          {!firstLoad && (
-            <Button
-              main
-              disabled={!authOk}
-              onClick={() => tryAuth(username, password)}
-            >
-              <IconArrowRight /> Login
-            </Button>
-          )}
-          <div style={{ flex: 1 }} />
-          {firstLoad && (
-            <Button
-              warn
-              disabled={!authBlank || confirm !== password}
-              onClick={() => tryAuth('', '')}
-            >
-              <IconLockOpen /> Skip
-            </Button>
-          )}
-        </Footer>
+        {phase === 'login' && (
+          <>
+            <Header attached>Brickadia Server Login</Header>
+            <PopoutContent>
+              <p>Welcome to the Omegga Web UI.</p>
+              {firstLoad && (
+                <p>
+                  Enter credentials for an Admin user. You can also skip this
+                  step if you don't want to use a password.
+                </p>
+              )}
+              {error && (
+                <p style={{ color: '#f66', textTransform: 'capitalize' }}>
+                  {error}
+                </p>
+              )}
+            </PopoutContent>
+            <div className="popout-inputs">
+              <Input
+                placeholder="Username"
+                type="text"
+                value={username}
+                onChange={setUsername}
+              />
+              <Input
+                placeholder="Password"
+                type="password"
+                value={password}
+                onChange={setPassword}
+                onSubmit={
+                  !firstLoad && authOk
+                    ? () => tryAuth(username, password)
+                    : undefined
+                }
+              />
+              {firstLoad && (
+                <Input
+                  placeholder="Confirm Password"
+                  type="password"
+                  value={confirm}
+                  onChange={setConfirm}
+                  onSubmit={
+                    authOk && confirm === password
+                      ? () => tryAuth(username, password)
+                      : undefined
+                  }
+                />
+              )}
+            </div>
+            <Footer attached>
+              {firstLoad && (
+                <Button
+                  main
+                  disabled={!authOk || confirm !== password}
+                  onClick={() => tryAuth(username, password)}
+                >
+                  <IconArrowRight /> Create
+                </Button>
+              )}
+              {!firstLoad && (
+                <Button
+                  main
+                  disabled={!authOk}
+                  onClick={() => tryAuth(username, password)}
+                >
+                  <IconArrowRight /> Login
+                </Button>
+              )}
+              <div style={{ flex: 1 }} />
+              {!firstLoad && canWebAuthn && (
+                <Button normal onClick={tryPasskey}>
+                  <IconFingerprint /> Passkey
+                </Button>
+              )}
+              {firstLoad && (
+                <Button
+                  warn
+                  disabled={!authBlank || confirm !== password}
+                  onClick={() => tryAuth('', '')}
+                >
+                  <IconLockOpen /> Skip
+                </Button>
+              )}
+            </Footer>
+          </>
+        )}
+        {phase === 'mfa-totp' && (
+          <>
+            <Header attached>Two-Factor Authentication</Header>
+            <PopoutContent>
+              <p>
+                {useRecovery
+                  ? 'Enter a recovery code to sign in.'
+                  : 'Enter the 6-digit code from your authenticator app.'}
+              </p>
+              {error && <p style={{ color: '#f66' }}>{error}</p>}
+            </PopoutContent>
+            <div className="popout-inputs">
+              <Input
+                placeholder={useRecovery ? 'Recovery code' : '000000'}
+                type="text"
+                value={totpCode}
+                onChange={setTotpCode}
+                onSubmit={totpCode ? submitTotp : undefined}
+              />
+            </div>
+            <Footer attached>
+              <Button main disabled={!totpCode} onClick={submitTotp}>
+                <IconShieldCheck /> Verify
+              </Button>
+              <div style={{ flex: 1 }} />
+              <Button
+                normal
+                onClick={() => {
+                  setUseRecovery(!useRecovery);
+                  setTotpCode('');
+                  setError('');
+                }}
+              >
+                <IconKey />
+                {useRecovery ? 'Use app' : 'Use recovery code'}
+              </Button>
+            </Footer>
+          </>
+        )}
         <Loader active={loading} blur size="huge">
           <b>AUTHORIZING</b>
         </Loader>

--- a/frontend/src/components/dropdown/dropdown.scss
+++ b/frontend/src/components/dropdown/dropdown.scss
@@ -8,10 +8,9 @@
   cursor: pointer;
   user-select: none;
   position: relative;
-  width: 100%;
 
   &:not(:last-child) {
-    margin-bottom: 0;
+    margin-right: 8px;
   }
 
   &.disabled {
@@ -23,11 +22,11 @@
   .options {
     position: absolute;
     bottom: 100%;
-    left: 0;
-    width: 100%;
+    right: 0;
+    width: max-content;
+    min-width: 100%;
     max-height: 200px;
     overflow-y: auto;
-    overflow-x: hidden;
     z-index: 10;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
     border-radius: theme.$br-radius-sm;
@@ -53,11 +52,19 @@
     background: theme.$br-element-normal;
     color: theme.$br-inverted-fg;
     height: theme.$br-element-height;
-    padding: 2px 12px;
-    padding-right: 0;
+    padding: 0 12px;
     box-sizing: border-box;
     font-weight: bold;
     font-size: theme.$br-element-font;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    white-space: nowrap;
+
+    .tabler-icon {
+      margin-right: 8px;
+      flex-shrink: 0;
+    }
 
     &:hover {
       background: theme.$br-element-overlay;
@@ -71,17 +78,11 @@
   }
 
   .selected {
-    display: flex;
     border: none;
-    align-items: center;
     border-radius: theme.$br-radius-sm;
 
     .value {
       flex: 1;
     }
-  }
-
-  .icon {
-    margin-right: 8px;
   }
 }

--- a/frontend/src/components/dropdown/index.tsx
+++ b/frontend/src/components/dropdown/index.tsx
@@ -1,4 +1,5 @@
 import { IconCaretDown } from '@tabler/icons-react';
+import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 export const Dropdown = ({
@@ -6,11 +7,13 @@ export const Dropdown = ({
   options = [],
   value,
   onChange,
+  icons,
 }: {
   disabled?: boolean;
   options: (string | number)[];
   value: string | number;
   onChange: (value: string | number) => void;
+  icons?: Record<string | number, React.ReactNode>;
 }) => {
   const [open, setOpen] = useState(false);
   const selfRef = useRef<HTMLDivElement>(null);
@@ -41,6 +44,7 @@ export const Dropdown = ({
                 onChange(o);
               }}
             >
+              {icons?.[o]}
               {o}
             </div>
           ))}

--- a/frontend/src/components/input/index.tsx
+++ b/frontend/src/components/input/index.tsx
@@ -9,6 +9,7 @@ export function Input<T extends 'text' | 'number' | 'password'>({
   roboto,
   onBlur,
   onFocus,
+  onSubmit,
   onChange,
   ...props
 }: {
@@ -18,8 +19,9 @@ export function Input<T extends 'text' | 'number' | 'password'>({
   roboto?: boolean;
   type?: T;
   value: T extends 'number' ? number : string;
+  onSubmit?: () => void;
   onChange?: (v: T extends 'number' ? number : string) => void;
-} & Omit<HTMLAttributes<HTMLInputElement>, 'onChange'>) {
+} & Omit<HTMLAttributes<HTMLInputElement>, 'onChange' | 'onSubmit'>) {
   return (
     <div
       className={`input ${disabled ? 'disabled' : ''} ${roboto ? 'roboto' : ''}`}
@@ -37,6 +39,16 @@ export function Input<T extends 'text' | 'number' | 'password'>({
           if (onChange)
             onChange(newValue as T extends 'number' ? number : string);
         }}
+        onKeyDown={
+          onSubmit
+            ? e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onSubmit();
+                }
+              }
+            : undefined
+        }
         {...props}
       />
     </div>

--- a/frontend/src/components/input/input.scss
+++ b/frontend/src/components/input/input.scss
@@ -1,4 +1,5 @@
 @use '../../css/theme';
+@use 'sass:color';
 
 .input {
   display: flex;
@@ -37,7 +38,7 @@
     border-radius: theme.$br-radius-sm;
 
     &::placeholder {
-      color: theme.$br-element-bg;
+      color: color.adjust(theme.$br-element-bg, $lightness: -5%);
     }
 
     &:focus {

--- a/frontend/src/components/modal/modal.scss
+++ b/frontend/src/components/modal/modal.scss
@@ -7,6 +7,7 @@
   width: 500px;
   opacity: 0;
   border-radius: theme.$br-radius-md;
+  overflow: hidden;
 
   &.visible {
     opacity: 1;

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -27,9 +27,10 @@ export const NavHeader = ({
     <div className={`main-nav ${className ?? ''}`}>
       <header className="nav-header">{title}</header>
       <NavBar>
-        <span style={{ flex: 1, marginLeft: 8 }}>
+        <span className="welcome" style={{ marginLeft: 8 }}>
           Welcome, {user?.username ?? '...'}
         </span>
+        <span style={{ flex: 1 }} />
         {children}
         {showLogout && (
           <Button

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -1,8 +1,16 @@
 import { useStore } from '@nanostores/react';
 import type { HTMLAttributes, PropsWithChildren } from 'react';
+import { useState } from 'react';
+import { Link } from 'wouter';
 import { Button } from '../button';
 import { logout } from '../../utils';
-import { IconLogout } from '@tabler/icons-react';
+import {
+  IconCaretDown,
+  IconCaretUp,
+  IconLogout,
+  IconUser,
+  IconUserCog,
+} from '@tabler/icons-react';
 import { $showLogout, $user } from '../../stores/user';
 
 export const NavBar = ({
@@ -22,25 +30,43 @@ export const NavHeader = ({
 }: PropsWithChildren<{ title: string; className?: string }>) => {
   const user = useStore($user);
   const showLogout = useStore($showLogout);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <div className={`main-nav ${className ?? ''}`}>
       <header className="nav-header">{title}</header>
       <NavBar>
-        <span className="welcome" style={{ marginLeft: 8 }}>
-          Welcome, {user?.username ?? '...'}
-        </span>
         <span style={{ flex: 1 }} />
         {children}
         {showLogout && (
-          <Button
-            icon
-            error
-            data-tooltip="Logout of Web UI"
-            onClick={() => logout()}
-          >
-            <IconLogout />
-          </Button>
+          <div className="widgets-container user-menu">
+            <Button normal boxy onClick={() => setMenuOpen(!menuOpen)}>
+              <IconUser />
+              <span className="user-menu-name">
+                {user?.username || 'Admin'}
+              </span>
+              {menuOpen ? <IconCaretUp /> : <IconCaretDown />}
+            </Button>
+            <div
+              className="widgets-list"
+              style={{ display: menuOpen ? 'block' : 'none' }}
+            >
+              <Link
+                href="/account"
+                className="button normal"
+                onClick={() => setMenuOpen(false)}
+              >
+                <div className="button-content">
+                  <IconUserCog />
+                  Account
+                </div>
+              </Link>
+              <Button error onClick={() => logout()}>
+                <IconLogout />
+                Logout
+              </Button>
+            </div>
+          </div>
         )}
       </NavBar>
     </div>

--- a/frontend/src/components/navbar/navbar.scss
+++ b/frontend/src/components/navbar/navbar.scss
@@ -28,8 +28,18 @@
   }
 }
 
-@media screen and (max-width: 1024px) {
-  .navbar .welcome {
-    display: none !important;
+.user-menu a,
+.user-menu a:visited {
+  text-decoration: none !important;
+  color: inherit !important;
+}
+
+.user-menu-name {
+  margin: 0 4px;
+}
+
+@media screen and (max-width: 600px) {
+  .user-menu-name {
+    display: none;
   }
 }

--- a/frontend/src/components/navbar/navbar.scss
+++ b/frontend/src/components/navbar/navbar.scss
@@ -27,3 +27,9 @@
     border-bottom-right-radius: 0;
   }
 }
+
+@media screen and (max-width: 1024px) {
+  .navbar .welcome {
+    display: none !important;
+  }
+}

--- a/frontend/src/components/sidenav/index.tsx
+++ b/frontend/src/components/sidenav/index.tsx
@@ -10,27 +10,35 @@ import {
 import type React from 'react';
 import { memo, type AnchorHTMLAttributes } from 'react';
 import { Link } from 'wouter';
+import { useHasAnyScope } from '@hooks';
+import { Domains, type Domain } from '../../permissions';
 
 export const MenuButton = ({
   children,
   disabled,
   to,
+  scope,
   ...props
 }: React.PropsWithChildren<{
   disabled?: boolean;
   to: string;
+  scope?: Domain;
 }> &
-  AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  <Link
-    href={to}
-    className={active =>
-      `menu-button ${disabled ? 'disabled' : ''} ${active ? 'active' : ''}`
-    }
-    {...props}
-  >
-    <div className="menu-button-content">{children}</div>
-  </Link>
-);
+  AnchorHTMLAttributes<HTMLAnchorElement>) => {
+  const hasScope = useHasAnyScope(scope);
+  if (!hasScope) return null;
+  return (
+    <Link
+      href={to}
+      className={active =>
+        `menu-button ${disabled ? 'disabled' : ''} ${active ? 'active' : ''}`
+      }
+      {...props}
+    >
+      <div className="menu-button-content">{children}</div>
+    </Link>
+  );
+};
 
 export const SideNav = memo(() => (
   <div className="main-menu-buttons">
@@ -41,26 +49,39 @@ export const SideNav = memo(() => (
       <IconDashboard style={{ background: '#de4f43' }} />
       Dashboard
     </MenuButton>
-    <MenuButton to="/worlds" data-tooltip="Manage worlds">
+    <MenuButton to="/worlds" scope={Domains.World} data-tooltip="Manage worlds">
       <IconWorld style={{ background: '#f0a500' }} />
       Worlds
     </MenuButton>
-    <MenuButton to="/history" data-tooltip="Browse chat history">
+    <MenuButton
+      to="/history"
+      scope={Domains.Chat}
+      data-tooltip="Browse chat history"
+    >
       <IconMessages style={{ background: '#008bd6' }} />
       History
     </MenuButton>
     <MenuButton
       to="/plugins"
+      scope={Domains.Plugin}
       data-tooltip="Manage, reload, and configure plugins"
     >
       <IconPlug style={{ background: '#00b35f' }} />
       Plugins
     </MenuButton>
-    <MenuButton to="/players" data-tooltip="Browse player info and play time">
+    <MenuButton
+      to="/players"
+      scope={Domains.Player}
+      data-tooltip="Browse player info and play time"
+    >
       <IconList style={{ background: '#b3006b' }} />
       Players
     </MenuButton>
-    <MenuButton to="/server" data-tooltip="Server management">
+    <MenuButton
+      to="/server"
+      scope={Domains.Server}
+      data-tooltip="Server management"
+    >
       <IconServer style={{ background: '#453d9c' }} />
       Server
     </MenuButton>

--- a/frontend/src/components/sidenav/index.tsx
+++ b/frontend/src/components/sidenav/index.tsx
@@ -5,13 +5,14 @@ import {
   IconPlug,
   IconServer,
   IconUser,
+  IconUserCog,
   IconWorld,
 } from '@tabler/icons-react';
 import type React from 'react';
 import { memo, type AnchorHTMLAttributes } from 'react';
 import { Link } from 'wouter';
-import { useHasAnyScope } from '@hooks';
-import { Domains, type Domain } from '../../permissions';
+import { useHasScope } from '@hooks';
+import { Permissions, type Permission } from '../../permissions';
 
 export const MenuButton = ({
   children,
@@ -22,11 +23,11 @@ export const MenuButton = ({
 }: React.PropsWithChildren<{
   disabled?: boolean;
   to: string;
-  scope?: Domain;
+  scope?: Permission;
 }> &
   AnchorHTMLAttributes<HTMLAnchorElement>) => {
-  const hasScope = useHasAnyScope(scope);
-  if (!hasScope) return null;
+  const hasScope = useHasScope(...(scope ? [scope] : []));
+  if (scope && !hasScope) return null;
   return (
     <Link
       href={to}
@@ -49,13 +50,17 @@ export const SideNav = memo(() => (
       <IconDashboard style={{ background: '#de4f43' }} />
       Dashboard
     </MenuButton>
-    <MenuButton to="/worlds" scope={Domains.World} data-tooltip="Manage worlds">
+    <MenuButton
+      to="/worlds"
+      scope={Permissions.WorldList}
+      data-tooltip="Manage worlds"
+    >
       <IconWorld style={{ background: '#f0a500' }} />
       Worlds
     </MenuButton>
     <MenuButton
       to="/history"
-      scope={Domains.Chat}
+      scope={Permissions.ChatHistory}
       data-tooltip="Browse chat history"
     >
       <IconMessages style={{ background: '#008bd6' }} />
@@ -63,7 +68,7 @@ export const SideNav = memo(() => (
     </MenuButton>
     <MenuButton
       to="/plugins"
-      scope={Domains.Plugin}
+      scope={Permissions.PluginList}
       data-tooltip="Manage, reload, and configure plugins"
     >
       <IconPlug style={{ background: '#00b35f' }} />
@@ -71,7 +76,7 @@ export const SideNav = memo(() => (
     </MenuButton>
     <MenuButton
       to="/players"
-      scope={Domains.Player}
+      scope={Permissions.PlayerList}
       data-tooltip="Browse player info and play time"
     >
       <IconList style={{ background: '#b3006b' }} />
@@ -79,15 +84,23 @@ export const SideNav = memo(() => (
     </MenuButton>
     <MenuButton
       to="/server"
-      scope={Domains.Server}
+      scope={Permissions.ServerStatus}
       data-tooltip="Server management"
     >
       <IconServer style={{ background: '#453d9c' }} />
       Server
     </MenuButton>
-    <MenuButton to="/users" data-tooltip="Server users">
+    <MenuButton
+      to="/users"
+      scope={Permissions.UserList}
+      data-tooltip="Server users"
+    >
       <IconUser style={{ background: '#7f0b8a' }} />
       Users
+    </MenuButton>
+    <MenuButton to="/account" data-tooltip="Your account settings">
+      <IconUserCog style={{ background: '#5a5a5a' }} />
+      Account
     </MenuButton>
   </div>
 ));

--- a/frontend/src/components/sidenav/sidenav.scss
+++ b/frontend/src/components/sidenav/sidenav.scss
@@ -70,7 +70,7 @@ $icon-height: $btn-height - 16px;
   }
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1400px) {
   .main-menu-buttons {
     width: 200px;
   }

--- a/frontend/src/components/sidenav/sidenav.scss
+++ b/frontend/src/components/sidenav/sidenav.scss
@@ -6,14 +6,6 @@
   margin-right: 8px;
 }
 
-@media screen and (max-width: 600px) {
-  .main-menu-buttons {
-    margin-right: 0;
-    width: 100%;
-    min-width: 100%;
-  }
-}
-
 $btn-height: 60px;
 $icon-height: $btn-height - 16px;
 
@@ -75,5 +67,36 @@ $icon-height: $btn-height - 16px;
 
   &:not(.disabled):active .menu-button-content {
     padding-top: 4px;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .main-menu-buttons {
+    width: 200px;
+  }
+
+  .menu-button {
+    width: 200px;
+    height: 40px;
+    font-size: 18px;
+
+    .ti,
+    .tabler-icon {
+      width: 28px;
+      height: 28px;
+      margin-right: 12px;
+    }
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .main-menu-buttons {
+    margin-right: 0;
+    width: 100%;
+    min-width: 100%;
+  }
+
+  .menu-button {
+    width: 100%;
   }
 }

--- a/frontend/src/css/style.scss
+++ b/frontend/src/css/style.scss
@@ -117,9 +117,9 @@ body {
 }
 
 .stats {
-  padding: 8px;
+  padding: 12px;
   font-size: 24px;
-  word-break: break-all;
+  word-break: break-word;
   background-color: theme.$br-element-popout-bg;
 }
 
@@ -245,17 +245,47 @@ a,
   }
 }
 
+@media screen and (max-width: 1024px) {
+  .inputs-list .inputs-item label {
+    min-width: 150px;
+  }
+}
+
 .widgets-container {
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  position: relative;
 
   .widgets-list {
+    position: absolute;
+    top: 100%;
+    right: 0;
     background-color: theme.$br-element-footer-bg;
-    margin-right: 8px;
     min-width: 200px;
     border-radius: theme.$br-radius-md;
+
+    > .button {
+      justify-content: flex-start;
+      white-space: nowrap;
+      width: 100%;
+      border-radius: 0;
+      margin-right: 0;
+      box-sizing: border-box;
+
+      &:first-child:not(.hidden) {
+        border-top-left-radius: theme.$br-radius-md;
+        border-top-right-radius: theme.$br-radius-md;
+      }
+
+      &:last-child {
+        border-bottom-left-radius: theme.$br-radius-md;
+        border-bottom-right-radius: theme.$br-radius-md;
+      }
+
+      &.hidden + .button {
+        border-top-left-radius: theme.$br-radius-md;
+        border-top-right-radius: theme.$br-radius-md;
+      }
+    }
 
     .widget-item {
       border-radius: theme.$br-radius-md;
@@ -275,6 +305,7 @@ a,
         text-transform: uppercase;
         display: flex;
         align-items: center;
+        margin-right: 10px;
 
         .tabler-icon {
           margin-right: 10px;
@@ -295,4 +326,8 @@ a,
 
 .spinning {
   animation: spin 1s linear infinite;
+}
+
+.hidden {
+  display: none !important;
 }

--- a/frontend/src/css/style.scss
+++ b/frontend/src/css/style.scss
@@ -245,7 +245,7 @@ a,
   }
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1200px) {
   .inputs-list .inputs-item label {
     min-width: 150px;
   }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,2 +1,2 @@
-export { useHasScope, useHasAnyScope, useRequireDomain } from './useHasScope';
+export { useHasScope, useHasAnyScope, useRequireScope } from './useHasScope';
 export { useSaved, SavedSpan, SavedStatus } from './useSaved';

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useHasScope, useHasAnyScope, useRequireDomain } from './useHasScope';
 export { useSaved, SavedSpan, SavedStatus } from './useSaved';

--- a/frontend/src/hooks/useHasScope.ts
+++ b/frontend/src/hooks/useHasScope.ts
@@ -1,29 +1,28 @@
 import { useStore } from '@nanostores/react';
 import { useEffect } from 'react';
 import { useLocation } from 'wouter';
-import type { Domain, Permission } from '../permissions';
+import type { Permission } from '../permissions';
 import { $resolvedScopes, $user } from '../stores/user';
 
 export const useHasScope = (...scopes: Permission[]): boolean => {
   const user = useStore($user);
   const resolved = useStore($resolvedScopes);
   if (user?.isOwner) return true;
+  if (scopes.length === 0) return true;
   return scopes.every(s => resolved[s]);
 };
 
-export const useHasAnyScope = (prefix?: Domain): boolean => {
+export const useHasAnyScope = (...scopes: Permission[]): boolean => {
   const user = useStore($user);
   const resolved = useStore($resolvedScopes);
-  if (!prefix) return true;
   if (user?.isOwner) return true;
-  return Object.entries(resolved).some(
-    ([k, v]) => k.startsWith(prefix + '.') && v,
-  );
+  if (scopes.length === 0) return true;
+  return scopes.some(s => resolved[s]);
 };
 
-export const useRequireDomain = (domain: Domain): boolean => {
+export const useRequireScope = (scope: Permission): boolean => {
   const user = useStore($user);
-  const allowed = useHasAnyScope(domain);
+  const allowed = useHasScope(scope);
   const [, navigate] = useLocation();
   useEffect(() => {
     if (user && !allowed) navigate('/');

--- a/frontend/src/hooks/useHasScope.ts
+++ b/frontend/src/hooks/useHasScope.ts
@@ -1,0 +1,32 @@
+import { useStore } from '@nanostores/react';
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
+import type { Domain, Permission } from '../permissions';
+import { $resolvedScopes, $user } from '../stores/user';
+
+export const useHasScope = (...scopes: Permission[]): boolean => {
+  const user = useStore($user);
+  const resolved = useStore($resolvedScopes);
+  if (user?.isOwner) return true;
+  return scopes.every(s => resolved[s]);
+};
+
+export const useHasAnyScope = (prefix?: Domain): boolean => {
+  const user = useStore($user);
+  const resolved = useStore($resolvedScopes);
+  if (!prefix) return true;
+  if (user?.isOwner) return true;
+  return Object.entries(resolved).some(
+    ([k, v]) => k.startsWith(prefix + '.') && v,
+  );
+};
+
+export const useRequireDomain = (domain: Domain): boolean => {
+  const user = useStore($user);
+  const allowed = useHasAnyScope(domain);
+  const [, navigate] = useLocation();
+  useEffect(() => {
+    if (user && !allowed) navigate('/');
+  }, [user, allowed]);
+  return allowed;
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,6 +7,7 @@ import './tooltip';
 import { trpc, trpcClient, queryClient } from './trpc';
 import { SessionInit } from './SessionInit';
 import { NotFound } from './views/NotFound';
+import { AccountView } from './views/account/AccountView';
 import { HistoryView } from './views/history';
 import { HomeView } from './views/home';
 import { PlayerList } from './views/players/PlayerList';
@@ -31,6 +32,7 @@ const App = () => (
       <Router hook={useBrowserLocation}>
         <Switch>
           <Route path="/" component={HomeView} />
+          <Route path="/account" component={AccountView} />
           <Route path="/history/:time?" component={HistoryView} />
           <Route path="/players/:id?" component={PlayerList} />
           <Route path="/plugins/:id?" component={PluginList} />

--- a/frontend/src/permissions.ts
+++ b/frontend/src/permissions.ts
@@ -1,0 +1,306 @@
+export const Permissions = {
+  // Chat
+  ChatSend: 'chat.send',
+  ChatRecent: 'chat.recent',
+  ChatHistory: 'chat.history',
+  ChatCalendar: 'chat.calendar',
+
+  // Player
+  PlayerList: 'player.list',
+  PlayerGet: 'player.get',
+  PlayerBan: 'player.ban',
+  PlayerKick: 'player.kick',
+  PlayerUnban: 'player.unban',
+  PlayerClearBricks: 'player.clearBricks',
+
+  // Plugin
+  PluginList: 'plugin.list',
+  PluginGet: 'plugin.get',
+  PluginConfig: 'plugin.config',
+  PluginLoad: 'plugin.load',
+  PluginUnload: 'plugin.unload',
+  PluginToggle: 'plugin.toggle',
+  PluginReloadAll: 'plugin.reloadAll',
+
+  // Server
+  ServerStatus: 'server.status',
+  ServerStart: 'server.start',
+  ServerStop: 'server.stop',
+  ServerRestart: 'server.restart',
+  ServerUpdateCheck: 'server.update.check',
+  ServerUpdateRun: 'server.update.run',
+  ServerAutorestartGet: 'server.autorestart.get',
+  ServerAutorestartSet: 'server.autorestart.set',
+  ServerUtilization: 'server.utilization',
+
+  // User
+  UserList: 'user.list',
+  UserCreate: 'user.create',
+  UserPasswd: 'user.passwd',
+  UserBan: 'user.ban',
+  UserDelete: 'user.delete',
+  UserPermissions: 'user.permissions',
+
+  // World
+  WorldList: 'world.list',
+  WorldActive: 'world.active',
+  WorldNext: 'world.next',
+  WorldRevisions: 'world.revisions',
+  WorldMeta: 'world.meta',
+  WorldLoad: 'world.load',
+  WorldUse: 'world.use',
+  WorldSave: 'world.save',
+  WorldCreate: 'world.create',
+
+  // Role
+  RoleList: 'role.list',
+
+  // Session
+  SessionInfo: 'session.info',
+} as const;
+
+export type Permission = (typeof Permissions)[keyof typeof Permissions];
+
+export const Domains = {
+  Chat: 'chat',
+  Player: 'player',
+  Plugin: 'plugin',
+  Server: 'server',
+  User: 'user',
+  World: 'world',
+} as const;
+
+export type Domain = (typeof Domains)[keyof typeof Domains];
+
+export const DOMAIN_LABELS: Record<string, string> = {
+  chat: 'Chat',
+  player: 'Player',
+  plugin: 'Plugin',
+  server: 'Server',
+  user: 'User',
+  world: 'World',
+};
+
+export const DOMAIN_ORDER: Domain[] = [
+  Domains.Chat,
+  Domains.Player,
+  Domains.Plugin,
+  Domains.Server,
+  Domains.User,
+  Domains.World,
+];
+
+export const SCOPE_INFO: Partial<
+  Record<Permission, { description: string; readOnly: boolean; domain: Domain }>
+> = {
+  [Permissions.ChatSend]: {
+    description: 'Send messages in the dashboard chat widget',
+    readOnly: false,
+    domain: Domains.Chat,
+  },
+  [Permissions.ChatRecent]: {
+    description: 'View recent chat on the dashboard',
+    readOnly: true,
+    domain: Domains.Chat,
+  },
+  [Permissions.ChatHistory]: {
+    description: 'Browse past chat logs in the history view',
+    readOnly: true,
+    domain: Domains.Chat,
+  },
+  [Permissions.ChatCalendar]: {
+    description: 'Navigate chat by date in the history view',
+    readOnly: true,
+    domain: Domains.Chat,
+  },
+  [Permissions.PlayerList]: {
+    description: 'View the player list in the players view',
+    readOnly: true,
+    domain: Domains.Player,
+  },
+  [Permissions.PlayerGet]: {
+    description: 'Inspect player details and history',
+    readOnly: true,
+    domain: Domains.Player,
+  },
+  [Permissions.PlayerBan]: {
+    description: 'Ban players from the player inspector',
+    readOnly: false,
+    domain: Domains.Player,
+  },
+  [Permissions.PlayerKick]: {
+    description: 'Kick players from the player inspector',
+    readOnly: false,
+    domain: Domains.Player,
+  },
+  [Permissions.PlayerUnban]: {
+    description: 'Unban players from the player inspector',
+    readOnly: false,
+    domain: Domains.Player,
+  },
+  [Permissions.PlayerClearBricks]: {
+    description: "Clear a player's bricks from the player inspector",
+    readOnly: false,
+    domain: Domains.Player,
+  },
+  [Permissions.PluginList]: {
+    description: 'View installed plugins in the plugins view',
+    readOnly: true,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginGet]: {
+    description: 'Inspect plugin details and configuration',
+    readOnly: true,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginConfig]: {
+    description: 'Edit plugin settings in the plugin inspector',
+    readOnly: false,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginLoad]: {
+    description: 'Load plugins from the plugin inspector',
+    readOnly: false,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginUnload]: {
+    description: 'Unload plugins from the plugin inspector',
+    readOnly: false,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginToggle]: {
+    description: 'Enable or disable plugins in the plugins view',
+    readOnly: false,
+    domain: Domains.Plugin,
+  },
+  [Permissions.PluginReloadAll]: {
+    description: 'Reload all plugins from the plugins view',
+    readOnly: false,
+    domain: Domains.Plugin,
+  },
+  [Permissions.ServerStatus]: {
+    description: 'View server status on the dashboard and server view',
+    readOnly: true,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerStart]: {
+    description: 'Start the server from the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerStop]: {
+    description: 'Stop the server from the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerRestart]: {
+    description: 'Restart the server from the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerUpdateCheck]: {
+    description: 'Check for server updates in the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerUpdateRun]: {
+    description: 'Run server updates from the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerAutorestartGet]: {
+    description: 'View auto-restart settings in the server view',
+    readOnly: true,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerAutorestartSet]: {
+    description: 'Change auto-restart settings in the server view',
+    readOnly: false,
+    domain: Domains.Server,
+  },
+  [Permissions.ServerUtilization]: {
+    description: 'View CPU, memory, and disk usage on the dashboard',
+    readOnly: true,
+    domain: Domains.Server,
+  },
+  [Permissions.UserList]: {
+    description: 'View web UI user accounts in the users view',
+    readOnly: true,
+    domain: Domains.User,
+  },
+  [Permissions.UserCreate]: {
+    description: 'Create new user accounts in the users view',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.UserPasswd]: {
+    description: 'Change user passwords in the users view',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.UserBan]: {
+    description: 'Disable or re-enable users in the user inspector',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.UserDelete]: {
+    description: 'Permanently delete user accounts',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.UserPermissions]: {
+    description: 'Edit user and default permissions in the users view',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.WorldList]: {
+    description: 'View available worlds in the worlds view',
+    readOnly: true,
+    domain: Domains.World,
+  },
+  [Permissions.WorldActive]: {
+    description: 'See which world is currently loaded',
+    readOnly: true,
+    domain: Domains.World,
+  },
+  [Permissions.WorldNext]: {
+    description: 'See which world will load next',
+    readOnly: true,
+    domain: Domains.World,
+  },
+  [Permissions.WorldRevisions]: {
+    description: 'View world save revisions in the world inspector',
+    readOnly: true,
+    domain: Domains.World,
+  },
+  [Permissions.WorldMeta]: {
+    description: 'View world metadata in the world inspector',
+    readOnly: true,
+    domain: Domains.World,
+  },
+  [Permissions.WorldLoad]: {
+    description: 'Load worlds from the world inspector',
+    readOnly: false,
+    domain: Domains.World,
+  },
+  [Permissions.WorldUse]: {
+    description: 'Set the default world in the worlds view',
+    readOnly: false,
+    domain: Domains.World,
+  },
+  [Permissions.WorldSave]: {
+    description: 'Save the current world from the worlds or server view',
+    readOnly: false,
+    domain: Domains.World,
+  },
+  [Permissions.WorldCreate]: {
+    description: 'Create new worlds in the worlds view',
+    readOnly: false,
+    domain: Domains.World,
+  },
+};
+
+export const SCOPES_BY_DOMAIN: Record<string, Permission[]> = {};
+for (const [scope, info] of Object.entries(SCOPE_INFO)) {
+  (SCOPES_BY_DOMAIN[info.domain] ??= []).push(scope as Permission);
+}

--- a/frontend/src/permissions.ts
+++ b/frontend/src/permissions.ts
@@ -40,6 +40,8 @@ export const Permissions = {
   UserBan: 'user.ban',
   UserDelete: 'user.delete',
   UserPermissions: 'user.permissions',
+  UserReadMfa: 'user.readMfa',
+  UserResetMfa: 'user.resetMfa',
 
   // World
   WorldList: 'world.list',
@@ -250,6 +252,16 @@ export const SCOPE_INFO: Partial<
   },
   [Permissions.UserPermissions]: {
     description: 'Edit user and default permissions in the users view',
+    readOnly: false,
+    domain: Domains.User,
+  },
+  [Permissions.UserReadMfa]: {
+    description: 'View MFA status of other users in the user inspector',
+    readOnly: true,
+    domain: Domains.User,
+  },
+  [Permissions.UserResetMfa]: {
+    description: 'Reset MFA for other users in the user inspector',
     readOnly: false,
     domain: Domains.User,
   },

--- a/frontend/src/stores/liveness.ts
+++ b/frontend/src/stores/liveness.ts
@@ -3,7 +3,7 @@ import { atom } from 'nanostores';
 import { useEffect } from 'react';
 import { useHasScope } from '@hooks';
 import { Permissions } from '../permissions';
-import { trpc, trpcClient } from '../trpc';
+import { handleGlobalError, trpc, trpcClient } from '../trpc';
 
 export const $liveness = atom<{
   starting: boolean;
@@ -36,6 +36,7 @@ export const useServerLiveness = () => {
 
   trpc.server.onStatus.useSubscription(undefined, {
     enabled: canStatus,
+    onError: handleGlobalError,
     onData(data) {
       $liveness.set({
         started: data.started,

--- a/frontend/src/stores/liveness.ts
+++ b/frontend/src/stores/liveness.ts
@@ -1,6 +1,8 @@
 import { useStore } from '@nanostores/react';
 import { atom } from 'nanostores';
 import { useEffect } from 'react';
+import { useHasScope } from '@hooks';
+import { Permissions } from '../permissions';
 import { trpc, trpcClient } from '../trpc';
 
 export const $liveness = atom<{
@@ -16,7 +18,10 @@ export const $liveness = atom<{
 });
 
 export const useServerLiveness = () => {
-  const { data } = trpc.server.started.useQuery();
+  const canStatus = useHasScope(Permissions.ServerStatus);
+  const { data } = trpc.server.started.useQuery(undefined, {
+    enabled: canStatus,
+  });
 
   useEffect(() => {
     if (data) {
@@ -30,6 +35,7 @@ export const useServerLiveness = () => {
   }, [data]);
 
   trpc.server.onStatus.useSubscription(undefined, {
+    enabled: canStatus,
     onData(data) {
       $liveness.set({
         started: data.started,

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -1,7 +1,11 @@
-import type { OmeggaSocketData } from '@backend/api';
+import type { RouterOutputs } from '../trpc';
 import { atom } from 'nanostores';
 
+type SessionInfo = RouterOutputs['session']['info'];
+
 export const $showLogout = atom(false);
-export const $user = atom<OmeggaSocketData['user'] | null>(null);
-export const $roles = atom<OmeggaSocketData['roles']>([]);
-export const $omeggaData = atom<OmeggaSocketData | null>(null);
+export const $user = atom<SessionInfo['user'] | null>(null);
+export const $roles = atom<SessionInfo['roles']>([]);
+export const $omeggaData = atom<SessionInfo | null>(null);
+export const $resolvedScopes = atom<Record<string, boolean>>({});
+export const $usersRefresh = atom(0);

--- a/frontend/src/trpc.ts
+++ b/frontend/src/trpc.ts
@@ -1,6 +1,6 @@
 import type { AppRouter } from '@backend/router';
 import { QueryClient } from '@tanstack/react-query';
-import { httpSubscriptionLink } from '@trpc/client';
+import { TRPCClientError, httpSubscriptionLink } from '@trpc/client';
 import { createTRPCReact, httpBatchLink, splitLink } from '@trpc/react-query';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
@@ -9,13 +9,35 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
 
 export const trpc = createTRPCReact<AppRouter>();
 
+export function handleGlobalError(error: unknown) {
+  if (error instanceof TRPCClientError && error.data?.code === 'UNAUTHORIZED') {
+    location.reload();
+  }
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 2,
+      retry: (count, error) => {
+        if (
+          error instanceof TRPCClientError &&
+          error.data?.code === 'UNAUTHORIZED'
+        )
+          return false;
+        return count < 2;
+      },
       staleTime: 5000,
     },
+    mutations: {
+      onError: handleGlobalError,
+    },
   },
+});
+
+queryClient.getQueryCache().subscribe(event => {
+  if (event.type === 'updated' && event.action.type === 'error') {
+    handleGlobalError(event.action.error);
+  }
 });
 
 export const trpcClient = trpc.createClient({

--- a/frontend/src/views/_index.scss
+++ b/frontend/src/views/_index.scss
@@ -3,4 +3,5 @@
 @use 'players';
 @use 'plugins';
 @use 'server';
+@use 'users';
 @use 'worlds';

--- a/frontend/src/views/_index.scss
+++ b/frontend/src/views/_index.scss
@@ -1,3 +1,4 @@
+@use 'account';
 @use 'history';
 @use 'home';
 @use 'players';

--- a/frontend/src/views/account/AccountView.tsx
+++ b/frontend/src/views/account/AccountView.tsx
@@ -1,0 +1,154 @@
+import {
+  Button,
+  Dimmer,
+  Footer,
+  Header,
+  Input,
+  Loader,
+  Modal,
+  NavHeader,
+  PageContent,
+  PopoutContent,
+  SideNav,
+} from '@components';
+import { useStore } from '@nanostores/react';
+import {
+  IconCaretDown,
+  IconCaretUp,
+  IconLock,
+  IconX,
+} from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { $user } from '../../stores/user';
+import { trpc } from '../../trpc';
+import { UserInspector } from '../users/UserInspector';
+
+export const AccountView = () => {
+  const myUser = useStore($user);
+  const passwdMutation = trpc.user.passwd.useMutation();
+
+  const [showActions, setShowActions] = useState(false);
+  const [showCredentials, setShowCredentials] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const username = myUser?.username ?? '';
+
+  const hideModal = () => {
+    setShowCredentials(false);
+    setError('');
+    setCurrentPassword('');
+    setPassword('');
+    setConfirmPassword('');
+  };
+
+  const submit = async () => {
+    setError('');
+    if (password !== confirmPassword) return;
+    setModalLoading(true);
+    try {
+      const err = await passwdMutation.mutateAsync({
+        username,
+        password,
+        currentPassword,
+      });
+      setModalLoading(false);
+      if (!err) {
+        hideModal();
+        return;
+      }
+      setError(err);
+    } catch (e) {
+      console.error('error setting password', e);
+      setModalLoading(false);
+    }
+  };
+
+  const ok = useMemo(
+    () =>
+      currentPassword.length > 0 &&
+      password.length > 0 &&
+      confirmPassword === password,
+    [currentPassword, password, confirmPassword],
+  );
+
+  return (
+    <>
+      <NavHeader title="Account">
+        <div className="widgets-container">
+          <Button normal boxy onClick={() => setShowActions(!showActions)}>
+            {showActions ? <IconCaretUp /> : <IconCaretDown />}
+            Actions
+          </Button>
+          <div
+            className="widgets-list"
+            style={{ display: showActions ? 'block' : 'none' }}
+          >
+            <Button
+              info
+              onClick={() => {
+                setShowActions(false);
+                setShowCredentials(true);
+              }}
+            >
+              <IconLock />
+              Change Password
+            </Button>
+          </div>
+        </div>
+      </NavHeader>
+      <PageContent>
+        <SideNav />
+        <div className="generic-container players-container">
+          <UserInspector selfUser={username} />
+        </div>
+        <Dimmer visible={showCredentials}>
+          <Loader active={modalLoading} size="huge">
+            Submitting
+          </Loader>
+          <Modal visible={!modalLoading}>
+            <Header>Change Password</Header>
+            <PopoutContent>
+              {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+            </PopoutContent>
+            <div className="popout-inputs">
+              <Input
+                placeholder="current password"
+                type="password"
+                value={currentPassword}
+                onChange={setCurrentPassword}
+              />
+              <Input
+                placeholder="new password"
+                type="password"
+                value={password}
+                onChange={setPassword}
+              />
+              <Input
+                placeholder="confirm new password"
+                type="password"
+                value={confirmPassword}
+                onChange={setConfirmPassword}
+                onSubmit={ok ? submit : undefined}
+              />
+            </div>
+            <Footer>
+              <Button main disabled={!ok} onClick={submit}>
+                <IconLock />
+                Update
+              </Button>
+              <div style={{ flex: 1 }} />
+              <Button normal onClick={hideModal}>
+                <IconX />
+                Cancel
+              </Button>
+            </Footer>
+          </Modal>
+        </Dimmer>
+      </PageContent>
+    </>
+  );
+};

--- a/frontend/src/views/account/_index.scss
+++ b/frontend/src/views/account/_index.scss
@@ -1,0 +1,1 @@
+// account view reuses player-inspector patterns -- no custom styles needed

--- a/frontend/src/views/history/_index.scss
+++ b/frontend/src/views/history/_index.scss
@@ -31,14 +31,15 @@
 }
 
 .calendar-container {
-  @include mixins.column;
+  position: relative;
   margin-right: 8px;
   z-index: 100;
-  min-height: 32px;
-  align-items: flex-end;
 }
 
 .calendar {
+  position: absolute;
+  top: 100%;
+  right: 0;
   background-color: theme.$br-element-footer-bg;
   border-radius: theme.$br-radius-md;
   min-width: 200px;

--- a/frontend/src/views/history/index.tsx
+++ b/frontend/src/views/history/index.tsx
@@ -7,7 +7,7 @@ import {
   PageContent,
   SideNav,
 } from '@components';
-import { useRequireDomain } from '@hooks';
+import { useHasScope, useRequireScope } from '@hooks';
 import {
   IconArrowLeft,
   IconArrowRight,
@@ -21,7 +21,7 @@ import React, {
   useState,
 } from 'react';
 import { useRoute } from 'wouter';
-import { Domains } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { trpc, type RouterOutputs } from '../../trpc';
 
 type ChatHistoryItem = RouterOutputs['chat']['history'][number];
@@ -51,7 +51,8 @@ const sorted = (obj: Record<number, any>, reverse = false) =>
     .sort((a, b) => (reverse ? b - a : a - b));
 
 export const HistoryView = () => {
-  const canAccess = useRequireDomain(Domains.Chat);
+  const canAccess = useRequireScope(Permissions.ChatHistory);
+  const canCalendar = useHasScope(Permissions.ChatCalendar);
   const [_, params] = useRoute('/history/:time?');
   const paramTime = params?.time;
 
@@ -172,7 +173,7 @@ export const HistoryView = () => {
       paramTime &&
       new Date(paramTime.match(/^\d+$/) ? Number(paramTime) : paramTime);
     (async () => {
-      if (firstLoad) await getCalendar();
+      if (firstLoad && canCalendar) await getCalendar();
 
       // ensures time is not nan
       if (time && !Number.isNaN(time.getTime())) {
@@ -280,94 +281,39 @@ export const HistoryView = () => {
   return (
     <>
       <NavHeader title="History">
-        <div className="calendar-container">
-          <Button
-            normal
-            boxy
-            style={{ marginRight: 0 }}
-            data-tooltip="Show a calendar previewing days"
-            onClick={() => setShowCalendar(!showCalendar)}
-          >
-            <IconCalendar /> Calendar
-          </Button>
-          {showCalendar && (
-            <div className="calendar">
-              <div className="year">
-                <Button
-                  icon
-                  normal
-                  disabled={!prevYear}
-                  onClick={() => setDate(prevYear)}
-                >
-                  <IconArrowLeft />
-                </Button>
-                {year}
-                <Button
-                  icon
-                  normal
-                  disabled={!nextYear}
-                  onClick={() => setDate(nextYear)}
-                >
-                  <IconArrowRight />
-                </Button>
-              </div>
-              <div className="month">
-                <Button
-                  icon
-                  normal
-                  disabled={!prevMonth}
-                  onClick={() => setDate(prevMonth)}
-                >
-                  <IconArrowLeft />
-                </Button>
-                {MONTHS[month]}
-                <Button
-                  icon
-                  normal
-                  disabled={!nextMonth}
-                  onClick={() => setDate(nextMonth)}
-                >
-                  <IconArrowRight />
-                </Button>
-              </div>
-              <div className="calendar-days">
-                <div className="week-header days">S</div>
-                <div className="week-header days">M</div>
-                <div className="week-header days">T</div>
-                <div className="week-header days">W</div>
-                <div className="week-header days">T</div>
-                <div className="week-header days">F</div>
-                <div className="week-header days">S</div>
-                {Array.from({ length: startDay }).map((_, i) => (
-                  <div key={`empty-${i}`} />
-                ))}
-                {Array.from({
-                  length: numDays,
-                }).map((_, d) => (
-                  <div
-                    key={d}
-                    className={`days ${
-                      nowMonth === month && nowYear === year && d + 1 === nowDay
-                        ? 'today'
-                        : ''
-                    } ${
-                      !(
-                        nowMonth === month &&
-                        nowYear === year &&
-                        d + 1 > nowDay
-                      ) && calendar[year]?.[month]?.[d]
-                        ? 'available'
-                        : ''
-                    }`}
-                    onClick={() => focusDay(year, month, d + 1)}
-                  >
-                    {d + 1}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+        {canCalendar && (
+          <div className="calendar-container">
+            <Button
+              normal
+              boxy
+              style={{ marginRight: 0 }}
+              data-tooltip="Show a calendar previewing days"
+              onClick={() => setShowCalendar(!showCalendar)}
+            >
+              <IconCalendar /> Calendar
+            </Button>
+            {showCalendar && (
+              <Calendar
+                {...{
+                  prevYear,
+                  setDate,
+                  year,
+                  nextYear,
+                  prevMonth,
+                  month,
+                  nextMonth,
+                  startDay,
+                  numDays,
+                  nowMonth,
+                  nowYear,
+                  nowDay,
+                  calendar,
+                  focusDay,
+                }}
+              />
+            )}
+          </div>
+        )}
       </NavHeader>
       <PageContent>
         <SideNav />
@@ -401,3 +347,108 @@ export const HistoryView = () => {
     </>
   );
 };
+
+const Calendar = ({
+  prevYear,
+  setDate,
+  year,
+  nextYear,
+  prevMonth,
+  month,
+  nextMonth,
+  startDay,
+  numDays,
+  nowMonth,
+  nowYear,
+  nowDay,
+  calendar,
+  focusDay,
+}: {
+  prevYear: [number, number] | null;
+  setDate: (date: [number, number] | null) => void;
+  year: number;
+  nextYear: [number, number] | null;
+  prevMonth: [number, number] | null;
+  month: number;
+  nextMonth: [number, number] | null;
+  startDay: number;
+  numDays: number;
+  nowMonth: number;
+  nowYear: number;
+  nowDay: number;
+  calendar: Record<number, Record<number, Record<number, boolean>>>;
+  focusDay: (year: number, month: number, day: number) => Promise<void>;
+}) => (
+  <div className="calendar">
+    <div className="year">
+      <Button
+        icon
+        normal
+        disabled={!prevYear}
+        onClick={() => setDate(prevYear)}
+      >
+        <IconArrowLeft />
+      </Button>
+      {year}
+      <Button
+        icon
+        normal
+        disabled={!nextYear}
+        onClick={() => setDate(nextYear)}
+      >
+        <IconArrowRight />
+      </Button>
+    </div>
+    <div className="month">
+      <Button
+        icon
+        normal
+        disabled={!prevMonth}
+        onClick={() => setDate(prevMonth)}
+      >
+        <IconArrowLeft />
+      </Button>
+      {MONTHS[month]}
+      <Button
+        icon
+        normal
+        disabled={!nextMonth}
+        onClick={() => setDate(nextMonth)}
+      >
+        <IconArrowRight />
+      </Button>
+    </div>
+    <div className="calendar-days">
+      <div className="week-header days">S</div>
+      <div className="week-header days">M</div>
+      <div className="week-header days">T</div>
+      <div className="week-header days">W</div>
+      <div className="week-header days">T</div>
+      <div className="week-header days">F</div>
+      <div className="week-header days">S</div>
+      {Array.from({ length: startDay }).map((_, i) => (
+        <div key={`empty-${i}`} />
+      ))}
+      {Array.from({
+        length: numDays,
+      }).map((_, d) => (
+        <div
+          key={d}
+          className={`days ${
+            nowMonth === month && nowYear === year && d + 1 === nowDay
+              ? 'today'
+              : ''
+          } ${
+            !(nowMonth === month && nowYear === year && d + 1 > nowDay) &&
+            calendar[year]?.[month]?.[d]
+              ? 'available'
+              : ''
+          }`}
+          onClick={() => focusDay(year, month, d + 1)}
+        >
+          {d + 1}
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/frontend/src/views/history/index.tsx
+++ b/frontend/src/views/history/index.tsx
@@ -7,6 +7,7 @@ import {
   PageContent,
   SideNav,
 } from '@components';
+import { useRequireDomain } from '@hooks';
 import {
   IconArrowLeft,
   IconArrowRight,
@@ -20,6 +21,7 @@ import React, {
   useState,
 } from 'react';
 import { useRoute } from 'wouter';
+import { Domains } from '../../permissions';
 import { trpc, type RouterOutputs } from '../../trpc';
 
 type ChatHistoryItem = RouterOutputs['chat']['history'][number];
@@ -49,6 +51,7 @@ const sorted = (obj: Record<number, any>, reverse = false) =>
     .sort((a, b) => (reverse ? b - a : a - b));
 
 export const HistoryView = () => {
+  const canAccess = useRequireDomain(Domains.Chat);
   const [_, params] = useRoute('/history/:time?');
   const paramTime = params?.time;
 
@@ -271,6 +274,8 @@ export const HistoryView = () => {
 
   const numDays = new Date(year, month + 1, 0).getDate();
   const startDay = new Date(year, month, 1).getDay();
+
+  if (!canAccess) return null;
 
   return (
     <>

--- a/frontend/src/views/home/_index.scss
+++ b/frontend/src/views/home/_index.scss
@@ -12,6 +12,18 @@
   z-index: 10;
 }
 
+.no-permissions-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  color: theme.$br-element-fg;
+  font-size: 24px;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
 .react-grid-layout {
   position: absolute;
   left: 0;

--- a/frontend/src/views/home/index.tsx
+++ b/frontend/src/views/home/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Header, NavHeader, PageContent, SideNav } from '@components';
+import { useHasScope } from '@hooks';
 import {
   IconApps,
   IconChevronDownRight,
@@ -9,25 +10,29 @@ import {
   IconPlus,
   IconX,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import GridLayout, { type Layout } from 'react-grid-layout';
+import { Permissions } from '../../permissions';
 import { ChatWidget, StatusWidget, UtilizationWidget } from '../../widgets';
 
-const WIDGET_LIST = {
+const WIDGET_DEFS = {
   chat: {
     component: ChatWidget,
     icon: IconMessageDots,
     tooltip: 'Chat with online players',
+    scope: Permissions.ChatRecent,
   },
   status: {
     component: StatusWidget,
     icon: IconList,
     tooltip: 'View current online players and server status',
+    scope: Permissions.ServerStatus,
   },
   utilization: {
     component: UtilizationWidget,
     icon: IconGauge,
     tooltip: 'View CPU, memory, disk, and network usage',
+    scope: Permissions.ServerUtilization,
   },
 };
 const DEFAULT_LAYOUT = [
@@ -44,6 +49,29 @@ const GRID_DATA = {
 const GRID_MARGIN = [8, 8] as [number, number];
 
 export const HomeView = () => {
+  const canChat = useHasScope(Permissions.ChatRecent);
+  const canStatus = useHasScope(Permissions.ServerStatus);
+  const canUtil = useHasScope(Permissions.ServerUtilization);
+
+  const allowedWidgets = useMemo(() => {
+    const allowed: Record<string, boolean> = {};
+    if (canChat) allowed.chat = true;
+    if (canStatus) allowed.status = true;
+    if (canUtil) allowed.utilization = true;
+    return allowed;
+  }, [canChat, canStatus, canUtil]);
+
+  const hasAnyPermission = canChat || canStatus || canUtil;
+
+  const WIDGET_LIST = useMemo(() => {
+    const list: Record<string, (typeof WIDGET_DEFS)[keyof typeof WIDGET_DEFS]> =
+      {};
+    for (const [k, v] of Object.entries(WIDGET_DEFS)) {
+      if (allowedWidgets[k]) list[k] = v;
+    }
+    return list;
+  }, [allowedWidgets]);
+
   const [layout, setLayout] = useState<Layout[]>(() => {
     if (localStorage.omeggaDashLayout2) {
       try {
@@ -59,6 +87,12 @@ export const HomeView = () => {
     }
     return DEFAULT_LAYOUT;
   });
+
+  const filteredLayout = useMemo(
+    () => layout.filter(w => allowedWidgets[w.i]),
+    [layout, allowedWidgets],
+  );
+
   useEffect(() => {
     localStorage.omeggaDashLayout2 = JSON.stringify(layout);
   }, [layout]);
@@ -112,56 +146,63 @@ export const HomeView = () => {
   return (
     <>
       <NavHeader title="Dashboard">
-        <div className="widgets-container">
-          <Button
-            normal
-            boxy
-            data-tooltip="Add more widgets to the dashboard"
-            onClick={() => setShowWidgets(!showWidgets)}
-          >
-            <IconApps />
-            Widgets
-          </Button>
-          <div
-            className="widgets-list"
-            style={{ display: showWidgets ? 'block' : 'none' }}
-          >
-            {Object.entries(WIDGET_LIST).map(([k, widget]) => (
-              <div key={k} className="widget-item">
-                <div className="name" data-tooltip={widget.tooltip}>
-                  <widget.icon />
-                  {k}
+        {hasAnyPermission && (
+          <div className="widgets-container">
+            <Button
+              normal
+              boxy
+              data-tooltip="Add more widgets to the dashboard"
+              onClick={() => setShowWidgets(!showWidgets)}
+            >
+              <IconApps />
+              Widgets
+            </Button>
+            <div
+              className="widgets-list"
+              style={{ display: showWidgets ? 'block' : 'none' }}
+            >
+              {Object.entries(WIDGET_LIST).map(([k, widget]) => (
+                <div key={k} className="widget-item">
+                  <div className="name" data-tooltip={widget.tooltip}>
+                    <widget.icon />
+                    {k}
+                  </div>
+                  {hasWidget[k] ? (
+                    <Button
+                      warn
+                      icon
+                      data-tooltip={`Remove ${k} widget`}
+                      onClick={() => removeWidget(k)}
+                    >
+                      <IconMinus />
+                    </Button>
+                  ) : (
+                    <Button
+                      main
+                      icon
+                      data-tooltip={`Add ${k} widget`}
+                      onClick={() => addWidget(k)}
+                    >
+                      <IconPlus />
+                    </Button>
+                  )}
                 </div>
-                {hasWidget[k] ? (
-                  <Button
-                    warn
-                    icon
-                    data-tooltip={`Remove ${k} widget`}
-                    onClick={() => removeWidget(k)}
-                  >
-                    <IconMinus />
-                  </Button>
-                ) : (
-                  <Button
-                    main
-                    icon
-                    data-tooltip={`Add ${k} widget`}
-                    onClick={() => addWidget(k)}
-                  >
-                    <IconPlus />
-                  </Button>
-                )}
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </NavHeader>
       <PageContent>
         <SideNav />
         <div className="grid-container" ref={containerRef}>
-          {width !== null && (
+          {!hasAnyPermission && (
+            <div className="no-permissions-message">
+              Contact your admin for support
+            </div>
+          )}
+          {hasAnyPermission && width !== null && (
             <GridLayout
-              layout={layout.map(l => ({ ...l, ...GRID_DATA }))}
+              layout={filteredLayout.map(l => ({ ...l, ...GRID_DATA }))}
               width={width}
               cols={10}
               autoSize
@@ -182,9 +223,10 @@ export const HomeView = () => {
                 />
               }
             >
-              {layout.map(item => {
+              {filteredLayout.map(item => {
                 const Component =
-                  WIDGET_LIST[item.i as keyof typeof WIDGET_LIST]!.component;
+                  WIDGET_LIST[item.i as keyof typeof WIDGET_LIST]?.component;
+                if (!Component) return null;
                 return (
                   <div key={item.i} className="grid-item">
                     <Header className="drag-handle">

--- a/frontend/src/views/players/PlayerInspector.tsx
+++ b/frontend/src/views/players/PlayerInspector.tsx
@@ -11,6 +11,7 @@ import {
   PopoutContent,
   Scroll,
 } from '@components';
+import { useHasScope } from '@hooks';
 import {
   IconBackspace,
   IconBan,
@@ -23,6 +24,7 @@ import {
 import { duration, heartbeatAgo, isoDate, isoTime } from '@utils';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useRoute } from 'wouter';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 
 const UNIT_SCALARS = {
@@ -52,6 +54,11 @@ export const PlayerInspector = () => {
   const [banDuration, setBanDuration] = useState(10);
   const [banUnit, setBanUnit] = useState('Permanent');
   const [actionLoading, setActionLoading] = useState(false);
+
+  const canBan = useHasScope(Permissions.PlayerBan);
+  const canKick = useHasScope(Permissions.PlayerKick);
+  const canUnban = useHasScope(Permissions.PlayerUnban);
+  const canClearBricks = useHasScope(Permissions.PlayerClearBricks);
 
   const {
     data: player,
@@ -147,19 +154,21 @@ export const PlayerInspector = () => {
               className="widgets-list"
               style={{ display: showActions ? 'block' : 'none' }}
             >
-              <Button
-                boxy
-                warn
-                disabled={actionLoading}
-                onClick={() => {
-                  setModal('clear');
-                  setShowActions(false);
-                }}
-              >
-                <IconEraser />
-                Clear Bricks
-              </Button>
-              {!player.isHost && player.isOnline && (
+              {canClearBricks && (
+                <Button
+                  boxy
+                  warn
+                  disabled={actionLoading}
+                  onClick={() => {
+                    setModal('clear');
+                    setShowActions(false);
+                  }}
+                >
+                  <IconEraser />
+                  Clear Bricks
+                </Button>
+              )}
+              {canKick && !player.isHost && player.isOnline && (
                 <Button
                   boxy
                   error
@@ -173,7 +182,7 @@ export const PlayerInspector = () => {
                   Kick
                 </Button>
               )}
-              {player.currentBan && (
+              {canUnban && player.currentBan && (
                 <Button
                   boxy
                   warn
@@ -187,7 +196,7 @@ export const PlayerInspector = () => {
                   Unban
                 </Button>
               )}
-              {!player.isHost && (
+              {canBan && !player.isHost && (
                 <Button
                   boxy
                   error

--- a/frontend/src/views/players/PlayerInspector.tsx
+++ b/frontend/src/views/players/PlayerInspector.tsx
@@ -55,6 +55,7 @@ export const PlayerInspector = () => {
   const [banUnit, setBanUnit] = useState('Permanent');
   const [actionLoading, setActionLoading] = useState(false);
 
+  const canGet = useHasScope(Permissions.PlayerGet);
   const canBan = useHasScope(Permissions.PlayerBan);
   const canKick = useHasScope(Permissions.PlayerKick);
   const canUnban = useHasScope(Permissions.PlayerUnban);
@@ -64,7 +65,9 @@ export const PlayerInspector = () => {
     data: player,
     isLoading: loading,
     refetch: getPlayer,
-  } = trpc.player.get.useQuery(params?.id ?? '', { enabled: !!params?.id });
+  } = trpc.player.get.useQuery(params?.id ?? '', {
+    enabled: !!params?.id && canGet,
+  });
 
   useEffect(() => {
     if (!loading && !player && params?.id) {

--- a/frontend/src/views/players/PlayerList.tsx
+++ b/frontend/src/views/players/PlayerList.tsx
@@ -21,16 +21,17 @@ import {
   IconMapPin,
   IconRotate,
 } from '@tabler/icons-react';
-import { useRequireDomain } from '@hooks';
+import { useHasScope, useRequireScope } from '@hooks';
 import { debounce, duration, heartbeatAgo } from '@utils';
 import { useMemo, useRef, useState } from 'react';
 import { Route, Switch, useLocation, useRoute } from 'wouter';
-import { Domains } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 import { PlayerInspector } from './PlayerInspector';
 
 export const PlayerList = () => {
-  const canAccess = useRequireDomain(Domains.Player);
+  const canAccess = useRequireScope(Permissions.PlayerList);
+  const canGet = useHasScope(Permissions.PlayerGet);
   const [showFilters, setShowFilters] = useState(false);
 
   const [_location, navigate] = useLocation();
@@ -354,10 +355,7 @@ export const PlayerList = () => {
           <Switch>
             <Route path="/players/:id" component={PlayerInspector} />
             <Route>
-              <div
-                className="player-inspector-container"
-                v-if="!$route.params.id"
-              >
+              <div className="player-inspector-container">
                 <NavBar attached>SELECT A PLAYER</NavBar>
                 <div className="player-inspector" />
               </div>

--- a/frontend/src/views/players/PlayerList.tsx
+++ b/frontend/src/views/players/PlayerList.tsx
@@ -21,13 +21,16 @@ import {
   IconMapPin,
   IconRotate,
 } from '@tabler/icons-react';
+import { useRequireDomain } from '@hooks';
 import { debounce, duration, heartbeatAgo } from '@utils';
 import { useMemo, useRef, useState } from 'react';
 import { Route, Switch, useLocation, useRoute } from 'wouter';
+import { Domains } from '../../permissions';
 import { trpc } from '../../trpc';
 import { PlayerInspector } from './PlayerInspector';
 
 export const PlayerList = () => {
+  const canAccess = useRequireDomain(Domains.Player);
   const [showFilters, setShowFilters] = useState(false);
 
   const [_location, navigate] = useLocation();
@@ -115,6 +118,8 @@ export const PlayerList = () => {
     }
     triggerFetch();
   };
+
+  if (!canAccess) return null;
 
   return (
     <>

--- a/frontend/src/views/players/player-inspector.scss
+++ b/frontend/src/views/players/player-inspector.scss
@@ -73,6 +73,7 @@
     top: 0;
     position: sticky;
     text-transform: uppercase;
+    z-index: 10;
   }
 
   table {

--- a/frontend/src/views/players/player-list.scss
+++ b/frontend/src/views/players/player-list.scss
@@ -59,7 +59,7 @@
   overflow: hidden;
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1200px) {
   .players-container {
     flex-direction: column;
   }

--- a/frontend/src/views/players/player-list.scss
+++ b/frontend/src/views/players/player-list.scss
@@ -58,3 +58,14 @@
   border-bottom-right-radius: theme.$br-radius-md;
   overflow: hidden;
 }
+
+@media screen and (max-width: 1024px) {
+  .players-container {
+    flex-direction: column;
+  }
+
+  .player-table-container {
+    margin-right: 0;
+    margin-bottom: 16px;
+  }
+}

--- a/frontend/src/views/plugins/PluginInspector.tsx
+++ b/frontend/src/views/plugins/PluginInspector.tsx
@@ -42,6 +42,7 @@ export const PluginInspector = () => {
   const [waiting, setWaiting] = useState(false);
   const [showSave, setShowSave] = useState<Record<string, boolean>>({});
 
+  const canGet = useHasScope(Permissions.PluginGet);
   const canLoad = useHasScope(Permissions.PluginLoad);
   const canUnload = useHasScope(Permissions.PluginUnload);
   const canToggle = useHasScope(Permissions.PluginToggle);
@@ -49,7 +50,7 @@ export const PluginInspector = () => {
 
   const getQuery = trpc.plugin.get.useQuery(
     { shortPath: params?.id ?? '' },
-    { enabled: !!params?.id },
+    { enabled: !!params?.id && canGet },
   );
 
   useEffect(() => {
@@ -105,6 +106,7 @@ export const PluginInspector = () => {
   pluginRef.current = plugin;
 
   trpc.plugin.onStatus.useSubscription(undefined, {
+    enabled: canGet,
     onData(data) {
       if (data.shortPath !== pluginRef.current?.path) return;
       setPlugin((prev: any) => ({ ...prev!, ...data }));

--- a/frontend/src/views/plugins/PluginInspector.tsx
+++ b/frontend/src/views/plugins/PluginInspector.tsx
@@ -25,7 +25,7 @@ import { debounce } from '@utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRoute } from 'wouter';
 import { Permissions } from '../../permissions';
-import { trpc } from '../../trpc';
+import { handleGlobalError, trpc } from '../../trpc';
 const jsonEq = (a: any, b: any) => {
   try {
     return JSON.stringify(a) === JSON.stringify(b);
@@ -107,6 +107,7 @@ export const PluginInspector = () => {
 
   trpc.plugin.onStatus.useSubscription(undefined, {
     enabled: canGet,
+    onError: handleGlobalError,
     onData(data) {
       if (data.shortPath !== pluginRef.current?.path) return;
       setPlugin((prev: any) => ({ ...prev!, ...data }));

--- a/frontend/src/views/plugins/PluginInspector.tsx
+++ b/frontend/src/views/plugins/PluginInspector.tsx
@@ -11,6 +11,7 @@ import {
   Scroll,
   Toggle,
 } from '@components';
+import { useHasScope } from '@hooks';
 import {
   IconArrowBackUp,
   IconCheck,
@@ -23,6 +24,7 @@ import {
 import { debounce } from '@utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRoute } from 'wouter';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 const jsonEq = (a: any, b: any) => {
   try {
@@ -39,6 +41,11 @@ export const PluginInspector = () => {
   const [loading, setLoading] = useState(Boolean(plugin?.path));
   const [waiting, setWaiting] = useState(false);
   const [showSave, setShowSave] = useState<Record<string, boolean>>({});
+
+  const canLoad = useHasScope(Permissions.PluginLoad);
+  const canUnload = useHasScope(Permissions.PluginUnload);
+  const canToggle = useHasScope(Permissions.PluginToggle);
+  const canConfig = useHasScope(Permissions.PluginConfig);
 
   const getQuery = trpc.plugin.get.useQuery(
     { shortPath: params?.id ?? '' },
@@ -220,6 +227,7 @@ export const PluginInspector = () => {
                               ? 'text'
                               : (conf.type as 'password' | 'number')
                           }
+                          disabled={!canConfig}
                           value={config[c] as string | number}
                           onChange={value => updateConfig(c, value)}
                         />
@@ -228,18 +236,21 @@ export const PluginInspector = () => {
                         <ListInput
                           options={'options' in conf ? conf.options : undefined}
                           type={conf.itemType}
+                          disabled={!canConfig}
                           value={config[c] as (string | number)[]}
                           onChange={value => updateConfig(c, value)}
                         />
                       )}
                       {conf.type === 'players' && (
                         <PlayerDropdown
+                          disabled={!canConfig}
                           value={config[c] as { id: string; name: string }[]}
                           onChange={value => updateConfig(c, value)}
                         />
                       )}
                       {conf.type === 'role' && (
                         <RoleDropdown
+                          disabled={!canConfig}
                           value={config[c] as string}
                           onChange={value => updateConfig(c, value)}
                         />
@@ -247,17 +258,19 @@ export const PluginInspector = () => {
                       {conf.type === 'enum' && (
                         <Dropdown
                           options={conf.options}
+                          disabled={!canConfig}
                           value={config[c] as string}
                           onChange={value => updateConfig(c, value)}
                         />
                       )}
                       {conf.type === 'boolean' && (
                         <Toggle
+                          disabled={!canConfig}
                           value={config[c] as boolean}
                           onChange={value => updateConfig(c, value)}
                         />
                       )}
-                      {!jsonEq(conf.default, config[c]) && (
+                      {canConfig && !jsonEq(conf.default, config[c]) && (
                         <IconArrowBackUp
                           onClick={() => updateConfig(c, conf.default)}
                           className="reset-button"
@@ -310,7 +323,7 @@ export const PluginInspector = () => {
         )}
       </div>
       <Footer attached>
-        {plugin?.isEnabled && !plugin.isLoaded && (
+        {canLoad && plugin?.isEnabled && !plugin.isLoaded && (
           <Button
             main
             disabled={waiting}
@@ -321,7 +334,7 @@ export const PluginInspector = () => {
             Load
           </Button>
         )}
-        {plugin?.isEnabled && plugin.isLoaded && (
+        {canLoad && canUnload && plugin?.isEnabled && plugin.isLoaded && (
           <Button
             warn
             data-tooltip="Stop, then start the plugin"
@@ -333,7 +346,7 @@ export const PluginInspector = () => {
           </Button>
         )}
         <span style={{ flex: 1 }} />
-        {plugin?.isEnabled && plugin.isLoaded && (
+        {canUnload && plugin?.isEnabled && plugin.isLoaded && (
           <Button
             error
             disabled={waiting}
@@ -344,7 +357,7 @@ export const PluginInspector = () => {
             Unload
           </Button>
         )}
-        {plugin && !plugin?.isEnabled && (
+        {canToggle && plugin && !plugin?.isEnabled && (
           <Button
             main
             data-tooltip="Allow the plugin to be started"
@@ -355,7 +368,7 @@ export const PluginInspector = () => {
             Enable
           </Button>
         )}
-        {plugin?.isEnabled && !plugin.isLoaded && (
+        {canToggle && plugin?.isEnabled && !plugin.isLoaded && (
           <Button
             error
             data-tooltip="Prevent the plugin from being started"

--- a/frontend/src/views/plugins/PluginList.tsx
+++ b/frontend/src/views/plugins/PluginList.tsx
@@ -20,7 +20,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useRoute } from 'wouter';
 import { Permissions } from '../../permissions';
-import { trpc } from '../../trpc';
+import { handleGlobalError, trpc } from '../../trpc';
 import { PluginInspector } from './PluginInspector';
 
 type PluginListItem = {
@@ -94,6 +94,7 @@ export const PluginList = () => {
 
   trpc.plugin.onStatus.useSubscription(undefined, {
     enabled: canAccess,
+    onError: handleGlobalError,
     onData(data) {
       const plugin = pluginStateFromInfo(data);
       setPlugins(prev =>

--- a/frontend/src/views/plugins/PluginList.tsx
+++ b/frontend/src/views/plugins/PluginList.tsx
@@ -8,7 +8,7 @@ import {
   Scroll,
   SideNav,
 } from '@components';
-import { useHasScope, useRequireDomain } from '@hooks';
+import { useHasScope, useRequireScope } from '@hooks';
 import {
   IconAlertCircle,
   IconBug,
@@ -19,7 +19,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useRoute } from 'wouter';
-import { Domains, Permissions } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 import { PluginInspector } from './PluginInspector';
 
@@ -51,7 +51,8 @@ const pluginStateFromInfo = (info: PluginInfo) => {
 type PluginRenderInfo = ReturnType<typeof pluginStateFromInfo>;
 
 export const PluginList = () => {
-  const canAccess = useRequireDomain(Domains.Plugin);
+  const canAccess = useRequireScope(Permissions.PluginList);
+  const canGet = useHasScope(Permissions.PluginGet);
   const [search, setSearch] = useState('');
   const [reloading, setReloading] = useState(false);
   const [plugins, setPlugins] = useState<any[]>([]);
@@ -92,6 +93,7 @@ export const PluginList = () => {
     plugin.name.toLowerCase().includes(search.toLowerCase());
 
   trpc.plugin.onStatus.useSubscription(undefined, {
+    enabled: canAccess,
     onData(data) {
       const plugin = pluginStateFromInfo(data);
       setPlugins(prev =>

--- a/frontend/src/views/plugins/PluginList.tsx
+++ b/frontend/src/views/plugins/PluginList.tsx
@@ -8,6 +8,7 @@ import {
   Scroll,
   SideNav,
 } from '@components';
+import { useHasScope, useRequireDomain } from '@hooks';
 import {
   IconAlertCircle,
   IconBug,
@@ -18,6 +19,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useRoute } from 'wouter';
+import { Domains, Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 import { PluginInspector } from './PluginInspector';
 
@@ -49,9 +51,12 @@ const pluginStateFromInfo = (info: PluginInfo) => {
 type PluginRenderInfo = ReturnType<typeof pluginStateFromInfo>;
 
 export const PluginList = () => {
+  const canAccess = useRequireDomain(Domains.Plugin);
   const [search, setSearch] = useState('');
   const [reloading, setReloading] = useState(false);
   const [plugins, setPlugins] = useState<any[]>([]);
+
+  const canReloadAll = useHasScope(Permissions.PluginReloadAll);
 
   const [_location, params] = useRoute('/plugins/:id?');
   const selectedPluginName = useMemo(
@@ -80,6 +85,7 @@ export const PluginList = () => {
     setReloading(true);
     await reloadAllMutation.mutateAsync();
     setReloading(false);
+    getPlugins();
   };
 
   const matches = (plugin: PluginRenderInfo) =>
@@ -94,19 +100,23 @@ export const PluginList = () => {
     },
   });
 
+  if (!canAccess) return null;
+
   return (
     <>
       <NavHeader title="Plugins">
         <span style={{ flex: 1 }} />
-        <Button
-          warn
-          disabled={reloading}
-          onClick={reloadPlugins}
-          data-tooltip="Reload all plugins, this may clear current plugin progress"
-        >
-          <IconRefreshAlert />
-          Reload Plugins
-        </Button>
+        {canReloadAll && (
+          <Button
+            warn
+            disabled={reloading}
+            onClick={reloadPlugins}
+            data-tooltip="Reload all plugins, this may clear current plugin progress"
+          >
+            <IconRefreshAlert />
+            Reload Plugins
+          </Button>
+        )}
       </NavHeader>
       <PageContent>
         <SideNav />

--- a/frontend/src/views/plugins/plugin-list.scss
+++ b/frontend/src/views/plugins/plugin-list.scss
@@ -90,7 +90,7 @@
   border-bottom-right-radius: theme.$br-radius-md;
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1200px) {
   .plugins-container {
     flex-direction: column;
   }

--- a/frontend/src/views/plugins/plugin-list.scss
+++ b/frontend/src/views/plugins/plugin-list.scss
@@ -89,3 +89,14 @@
   border-bottom-left-radius: theme.$br-radius-md;
   border-bottom-right-radius: theme.$br-radius-md;
 }
+
+@media screen and (max-width: 1024px) {
+  .plugins-container {
+    flex-direction: column;
+  }
+
+  .plugins-list-container {
+    margin-right: 0;
+    margin-bottom: 16px;
+  }
+}

--- a/frontend/src/views/server/_index.scss
+++ b/frontend/src/views/server/_index.scss
@@ -35,5 +35,7 @@
 .buttons {
   flex-direction: row;
   display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
   margin-top: 8px;
 }

--- a/frontend/src/views/server/_index.scss
+++ b/frontend/src/views/server/_index.scss
@@ -6,7 +6,9 @@
   flex-direction: column;
 
   .navbar {
-    margin-top: 8px;
+    &:not(.server-status) {
+      margin-top: 8px;
+    }
     text-transform: uppercase;
 
     .saved-note {

--- a/frontend/src/views/server/index.tsx
+++ b/frontend/src/views/server/index.tsx
@@ -13,7 +13,7 @@ import {
   SavedSpan,
   SavedStatus,
   useHasScope,
-  useRequireDomain,
+  useRequireScope,
   useSaved,
 } from '@hooks';
 import { useStore } from '@nanostores/react';
@@ -35,7 +35,7 @@ import {
   updateServer,
   useServerLiveness,
 } from '../../stores/liveness';
-import { Domains, Permissions } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { $omeggaData } from '../../stores/user';
 import { trpc } from '../../trpc';
 
@@ -49,7 +49,7 @@ function formatTimeAgo(timestamp: number): string {
 }
 
 export const ServerView = () => {
-  const canAccess = useRequireDomain(Domains.Server);
+  const canAccess = useRequireScope(Permissions.ServerStatus);
   const {
     started,
     stopping,
@@ -62,6 +62,8 @@ export const ServerView = () => {
   const canStop = useHasScope(Permissions.ServerStop);
   const canRestart = useHasScope(Permissions.ServerRestart);
   const canUpdate = useHasScope(Permissions.ServerUpdateRun);
+  const canViewAutoRestart = useHasScope(Permissions.ServerAutorestartGet);
+  const canUpdateCheck = useHasScope(Permissions.ServerUpdateCheck);
   const canAutoRestart = useHasScope(Permissions.ServerAutorestartSet);
   const canSaveWorld = useHasScope(Permissions.WorldSave);
 
@@ -78,7 +80,10 @@ export const ServerView = () => {
 
   const [savingWorld, setSavingWorld] = useState(false);
 
-  const { data: autoRestartData } = trpc.server.autoRestart.get.useQuery();
+  const { data: autoRestartData } = trpc.server.autoRestart.get.useQuery(
+    undefined,
+    { enabled: canViewAutoRestart },
+  );
 
   useEffect(() => {
     if (autoRestartData) {
@@ -86,21 +91,21 @@ export const ServerView = () => {
     }
   }, [autoRestartData]);
 
-  const canUpdateCheck = omeggaData?.update?.canCheck ?? false;
+  const hasSteam = omeggaData?.update?.canCheck ?? false;
 
   const updateCheckQuery = trpc.server.update.check.useQuery(undefined, {
     enabled: false,
   });
 
   const checkForUpdate = useCallback(() => {
-    if (!canUpdateCheck) return;
+    if (!hasSteam || !canUpdateCheck) return;
     setCheckingForUpdate(true);
     updateCheckQuery.refetch().then(({ data }) => {
       setHasUpdate(data ?? null);
       setLastCheckedAt(Date.now());
       setCheckingForUpdate(false);
     });
-  }, [canUpdateCheck, updateCheckQuery]);
+  }, [hasSteam, canUpdateCheck, updateCheckQuery]);
 
   const autoRestartSetMutation = trpc.server.autoRestart.set.useMutation();
 
@@ -153,7 +158,7 @@ export const ServerView = () => {
   return (
     <>
       <NavHeader title="Server">
-        {canUpdateCheck && (
+        {hasSteam && canUpdateCheck && (
           <Button
             main={Boolean(hasUpdate)}
             normal={!hasUpdate}
@@ -183,7 +188,7 @@ export const ServerView = () => {
       <PageContent>
         <SideNav />
         <div className="generic-container server-container">
-          <NavBar>
+          <NavBar className="server-status">
             Server Status:{' '}
             {starting
               ? 'starting'
@@ -192,7 +197,7 @@ export const ServerView = () => {
                 : started
                   ? 'started'
                   : 'stopped'}
-            {canUpdateCheck && hasUpdate !== null && (
+            {hasSteam && canUpdateCheck && hasUpdate !== null && (
               <span style={{ marginLeft: 8, fontSize: '0.75em', opacity: 0.7 }}>
                 {hasUpdate
                   ? 'Update available'
@@ -276,11 +281,13 @@ export const ServerView = () => {
               </Button>
             )}
           </div>
-          <NavBar attached style={{ marginTop: 8 }}>
-            Auto Restart
-            <SavedSpan show={saved.status === SavedStatus.Waiting} />
-          </NavBar>
-          {config && (
+          {canViewAutoRestart && (
+            <NavBar attached style={{ marginTop: 8 }}>
+              Auto Restart
+              <SavedSpan show={saved.status === SavedStatus.Waiting} />
+            </NavBar>
+          )}
+          {canViewAutoRestart && config && (
             <div className="inputs-list">
               <div
                 className="inputs-item"
@@ -302,7 +309,7 @@ export const ServerView = () => {
               >
                 <label>
                   Auto Update
-                  {canUpdateCheck ? '' : ' (SteamCMD Only)'}
+                  {hasSteam ? '' : ' (SteamCMD Only)'}
                 </label>
                 <div className="inputs">
                   <Toggle

--- a/frontend/src/views/server/index.tsx
+++ b/frontend/src/views/server/index.tsx
@@ -9,7 +9,13 @@ import {
   Toggle,
   useConfirm,
 } from '@components';
-import { SavedSpan, SavedStatus, useSaved } from '@hooks';
+import {
+  SavedSpan,
+  SavedStatus,
+  useHasScope,
+  useRequireDomain,
+  useSaved,
+} from '@hooks';
 import { useStore } from '@nanostores/react';
 import {
   IconCloudDownload,
@@ -29,6 +35,7 @@ import {
   updateServer,
   useServerLiveness,
 } from '../../stores/liveness';
+import { Domains, Permissions } from '../../permissions';
 import { $omeggaData } from '../../stores/user';
 import { trpc } from '../../trpc';
 
@@ -42,6 +49,7 @@ function formatTimeAgo(timestamp: number): string {
 }
 
 export const ServerView = () => {
+  const canAccess = useRequireDomain(Domains.Server);
   const {
     started,
     stopping,
@@ -49,6 +57,13 @@ export const ServerView = () => {
     loading: statusLoading,
   } = useServerLiveness();
   const confirm = useConfirm();
+
+  const canStart = useHasScope(Permissions.ServerStart);
+  const canStop = useHasScope(Permissions.ServerStop);
+  const canRestart = useHasScope(Permissions.ServerRestart);
+  const canUpdate = useHasScope(Permissions.ServerUpdateRun);
+  const canAutoRestart = useHasScope(Permissions.ServerAutorestartSet);
+  const canSaveWorld = useHasScope(Permissions.WorldSave);
 
   const [config, setConfig] = useState<IStoreAutoRestartConfig | null>(null);
   const omeggaData = useStore($omeggaData);
@@ -133,6 +148,8 @@ export const ServerView = () => {
     };
   };
 
+  if (!canAccess) return null;
+
   return (
     <>
       <NavHeader title="Server">
@@ -184,53 +201,63 @@ export const ServerView = () => {
             )}
           </NavBar>
           <div className="buttons">
-            <Button
-              main
-              data-tooltip="Start the server"
-              disabled={starting || stopping || statusLoading || started}
-              onClick={() =>
-                confirm
-                  .prompt('start the server')
-                  .then(ok => ok && startServer())
-              }
-            >
-              <IconPlayerPlay />
-              Start
-            </Button>
-            <Button
-              error
-              data-tooltip="Stop the server"
-              disabled={starting || stopping || statusLoading || !started}
-              onClick={() =>
-                confirm.prompt('stop the server').then(ok => ok && stopServer())
-              }
-            >
-              <IconPlayerStop />
-              Stop
-            </Button>
-            <Button
-              warn
-              data-tooltip="Reloads the server's world. Saves minigames/environment/bricks if 'Save World' is enabled below."
-              disabled={starting || stopping || statusLoading}
-              onClick={() =>
-                confirm
-                  .prompt('restart the server')
-                  .then(ok => ok && restartServer())
-              }
-            >
-              <IconRefresh />
-              Restart
-            </Button>
-            <Button
-              info
-              data-tooltip="Save the current world."
-              disabled={starting || stopping || statusLoading || savingWorld}
-              onClick={saveWorld}
-            >
-              <IconDeviceFloppy />
-              Save World
-            </Button>
-            {omeggaData?.isSteam && (
+            {canStart && (
+              <Button
+                main
+                data-tooltip="Start the server"
+                disabled={starting || stopping || statusLoading || started}
+                onClick={() =>
+                  confirm
+                    .prompt('start the server')
+                    .then(ok => ok && startServer())
+                }
+              >
+                <IconPlayerPlay />
+                Start
+              </Button>
+            )}
+            {canStop && (
+              <Button
+                error
+                data-tooltip="Stop the server"
+                disabled={starting || stopping || statusLoading || !started}
+                onClick={() =>
+                  confirm
+                    .prompt('stop the server')
+                    .then(ok => ok && stopServer())
+                }
+              >
+                <IconPlayerStop />
+                Stop
+              </Button>
+            )}
+            {canRestart && (
+              <Button
+                warn
+                data-tooltip="Reloads the server's world. Saves minigames/environment/bricks if 'Save World' is enabled below."
+                disabled={starting || stopping || statusLoading}
+                onClick={() =>
+                  confirm
+                    .prompt('restart the server')
+                    .then(ok => ok && restartServer())
+                }
+              >
+                <IconRefresh />
+                Restart
+              </Button>
+            )}
+            {canSaveWorld && (
+              <Button
+                info
+                data-tooltip="Save the current world."
+                disabled={starting || stopping || statusLoading || savingWorld}
+                onClick={saveWorld}
+              >
+                <IconDeviceFloppy />
+                Save World
+              </Button>
+            )}
+            {canUpdate && omeggaData?.isSteam && (
               <Button
                 normal={!hasUpdate}
                 main={hasUpdate === true}
@@ -262,6 +289,7 @@ export const ServerView = () => {
                 <label>Restart on Crash</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.crashRestartEnabled ?? true}
                     onChange={changeConfig('crashRestartEnabled')}
@@ -278,11 +306,13 @@ export const ServerView = () => {
                 </label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.autoUpdateEnabled}
                     onChange={changeConfig('autoUpdateEnabled')}
                   />
                   <Input
+                    disabled={!canAutoRestart}
                     type="number"
                     placeholder="Minutes"
                     tooltip="Interval in minutes to check for updates (min 10)"
@@ -298,11 +328,13 @@ export const ServerView = () => {
                 <label>Max Server Uptime (Hours)</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.maxUptimeEnabled}
                     onChange={changeConfig('maxUptimeEnabled')}
                   />
                   <Input
+                    disabled={!canAutoRestart}
                     type="number"
                     placeholder="Hours"
                     tooltip="Uptime Hours"
@@ -318,11 +350,13 @@ export const ServerView = () => {
                 <label>Empty Server Lifetime (Hours)</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.emptyUptimeEnabled}
                     onChange={changeConfig('emptyUptimeEnabled')}
                   />
                   <Input
+                    disabled={!canAutoRestart}
                     type="number"
                     placeholder="Hours"
                     tooltip="Uptime Hours"
@@ -338,11 +372,13 @@ export const ServerView = () => {
                 <label>Daily at a Specific Hour</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.dailyHourEnabled}
                     onChange={changeConfig('dailyHourEnabled')}
                   />
                   <Input
+                    disabled={!canAutoRestart}
                     type="number"
                     placeholder="Hour"
                     tooltip="Hour (0 = 12am, 13 = 1pm)"
@@ -358,6 +394,7 @@ export const ServerView = () => {
                 <label>Restart Announcement</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.announcementEnabled}
                     onChange={changeConfig('announcementEnabled')}
@@ -371,6 +408,7 @@ export const ServerView = () => {
                 <label>Reload Players</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.playersEnabled}
                     onChange={changeConfig('playersEnabled')}
@@ -384,6 +422,7 @@ export const ServerView = () => {
                 <label>Save World</label>
                 <div className="inputs">
                   <Toggle
+                    disabled={!canAutoRestart}
                     tooltip="Enabled"
                     value={config.saveWorld ?? true}
                     onChange={changeConfig('saveWorld')}

--- a/frontend/src/views/users/DefaultPermissions.tsx
+++ b/frontend/src/views/users/DefaultPermissions.tsx
@@ -47,12 +47,7 @@ export const DefaultPermissions = () => {
       <NavBar attached>
         Default Permissions
         <span style={{ flex: 1 }} />
-        <Button
-          normal
-          boxy
-          disabled={saving || !dirty}
-          onClick={save}
-        >
+        <Button normal disabled={saving || !dirty} onClick={save}>
           <IconDeviceFloppy />
           Save
         </Button>

--- a/frontend/src/views/users/DefaultPermissions.tsx
+++ b/frontend/src/views/users/DefaultPermissions.tsx
@@ -1,0 +1,83 @@
+import { Button, Loader, NavBar, Scroll } from '@components';
+import { IconDeviceFloppy } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { trpc } from '../../trpc';
+import { PermissionEditor, type PermissionSet } from './PermissionEditor';
+
+export const DefaultPermissions = () => {
+  const defaultPermsQuery = trpc.user.defaultPermissions.get.useQuery();
+  const setDefaultPermsMutation =
+    trpc.user.defaultPermissions.set.useMutation();
+
+  const [editPerms, setEditPerms] = useState<PermissionSet | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (defaultPermsQuery.data) {
+      setEditPerms({
+        root: (defaultPermsQuery.data.root as PermissionSet['root']) ?? 'off',
+        domains:
+          (defaultPermsQuery.data.domains as PermissionSet['domains']) ?? {},
+        scopes:
+          (defaultPermsQuery.data.scopes as PermissionSet['scopes']) ?? {},
+      });
+    }
+  }, [defaultPermsQuery.data]);
+
+  const dirty = useMemo(() => {
+    if (!editPerms || !defaultPermsQuery.data) return false;
+    return JSON.stringify(editPerms) !== JSON.stringify(defaultPermsQuery.data);
+  }, [editPerms, defaultPermsQuery.data]);
+
+  const save = useCallback(async () => {
+    if (!editPerms) return;
+    setSaving(true);
+    try {
+      const err = await setDefaultPermsMutation.mutateAsync(editPerms);
+      if (err) console.error('Failed to save default permissions:', err);
+      else defaultPermsQuery.refetch();
+    } catch (e) {
+      console.error('Failed to save default permissions:', e);
+    }
+    setSaving(false);
+  }, [editPerms]);
+
+  return (
+    <div className="player-inspector-container">
+      <NavBar attached>
+        Default Permissions
+        <span style={{ flex: 1 }} />
+        <Button
+          normal
+          boxy
+          disabled={saving || !dirty}
+          onClick={save}
+        >
+          <IconDeviceFloppy />
+          Save
+        </Button>
+      </NavBar>
+      <div className="player-inspector">
+        <div className="player-view">
+          <Loader active={defaultPermsQuery.isLoading} size="huge">
+            Loading Defaults
+          </Loader>
+          <div className="player-info">
+            {editPerms && (
+              <Scroll>
+                <div className="stats">
+                  <div className="stat">
+                    These permissions apply to all users who don't have an
+                    explicit override set.
+                  </div>
+                </div>
+                <div className="section-header">Permissions</div>
+                <PermissionEditor perms={editPerms} onChange={setEditPerms} />
+              </Scroll>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/views/users/MfaManager.tsx
+++ b/frontend/src/views/users/MfaManager.tsx
@@ -1,0 +1,388 @@
+import { Button, Input, Loader } from '@components';
+import {
+  IconCheck,
+  IconCopy,
+  IconFingerprint,
+  IconKey,
+  IconPlus,
+  IconShieldCheck,
+  IconTrash,
+  IconX,
+} from '@tabler/icons-react';
+import { useCallback, useState } from 'react';
+import { trpc } from '../../trpc';
+
+const SectionError = ({ error }: { error: string }) =>
+  error ? <div className="mfa-error">{error}</div> : null;
+
+export const MfaManager = () => {
+  const mfaStatus = trpc.mfa.status.useQuery();
+  const totpSetup = trpc.mfa.totp.setup.useMutation();
+  const totpEnable = trpc.mfa.totp.enable.useMutation();
+  const totpDisable = trpc.mfa.totp.disable.useMutation();
+  const passkeyOpts = trpc.mfa.passkey.registerOptions.useMutation();
+  const passkeyRegister = trpc.mfa.passkey.register.useMutation();
+  const passkeyRemove = trpc.mfa.passkey.remove.useMutation();
+  const recoveryGen = trpc.mfa.recoveryCodes.generate.useMutation();
+
+  const [setupData, setSetupData] = useState<{
+    secret: string;
+    qrCode: string;
+  } | null>(null);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [totpPassword, setTotpPassword] = useState('');
+  const [passkeyPassword, setPasskeyPassword] = useState('');
+  const [recoveryPassword, setRecoveryPassword] = useState('');
+  const [passkeyName, setPasskeyName] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [totpError, setTotpError] = useState('');
+  const [passkeyError, setPasskeyError] = useState('');
+  const [recoveryError, setRecoveryError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const canWebAuthn =
+    typeof window !== 'undefined' &&
+    !!window.PublicKeyCredential &&
+    (location.protocol === 'https:' || location.hostname === 'localhost');
+
+  const startTotpSetup = useCallback(async () => {
+    if (!totpPassword) return;
+    setTotpError('');
+    setBusy(true);
+    const data = await totpSetup.mutateAsync({ password: totpPassword });
+    setBusy(false);
+    if ('error' in data && data.error) {
+      setTotpError(data.error);
+    } else if ('secret' in data) {
+      setSetupData(data as { secret: string; qrCode: string });
+      setVerifyCode('');
+      setTotpPassword('');
+    }
+  }, [totpPassword]);
+
+  const confirmTotp = useCallback(async () => {
+    if (!setupData) return;
+    setTotpError('');
+    setBusy(true);
+    const err = await totpEnable.mutateAsync({ code: verifyCode });
+    setBusy(false);
+    if (err) {
+      setTotpError(err);
+    } else {
+      setSetupData(null);
+      setVerifyCode('');
+      mfaStatus.refetch();
+    }
+  }, [setupData, verifyCode]);
+
+  const disableTotp = useCallback(async () => {
+    if (!totpPassword) return;
+    setTotpError('');
+    setBusy(true);
+    const err = await totpDisable.mutateAsync({ password: totpPassword });
+    setBusy(false);
+    if (err) {
+      setTotpError(err);
+    } else {
+      setTotpPassword('');
+      mfaStatus.refetch();
+    }
+  }, [totpPassword]);
+
+  const addPasskey = useCallback(async () => {
+    setPasskeyError('');
+    setBusy(true);
+    try {
+      const options = await passkeyOpts.mutateAsync();
+      const { startRegistration } = await import('@simplewebauthn/browser');
+      const credential = await startRegistration({ optionsJSON: options });
+      const err = await passkeyRegister.mutateAsync({
+        credential,
+        name: passkeyName || 'Passkey',
+      });
+      if (err) setPasskeyError(err);
+      else {
+        setPasskeyName('');
+        mfaStatus.refetch();
+      }
+    } catch (e: any) {
+      if (e?.name !== 'NotAllowedError')
+        setPasskeyError(e?.message || 'Registration failed');
+    }
+    setBusy(false);
+  }, [passkeyName]);
+
+  const removePasskey = useCallback(
+    async (id: string) => {
+      if (!passkeyPassword) {
+        setPasskeyError('Enter your password to remove a passkey');
+        return;
+      }
+      setPasskeyError('');
+      setBusy(true);
+      const err = await passkeyRemove.mutateAsync({
+        id,
+        password: passkeyPassword,
+      });
+      if (err) setPasskeyError(err);
+      else {
+        setPasskeyPassword('');
+        mfaStatus.refetch();
+      }
+      setBusy(false);
+    },
+    [passkeyPassword],
+  );
+
+  const generateRecovery = useCallback(async () => {
+    if (!recoveryPassword) return;
+    setRecoveryError('');
+    setBusy(true);
+    const result = await recoveryGen.mutateAsync({
+      password: recoveryPassword,
+    });
+    if ('error' in result && result.error) {
+      setRecoveryError(result.error);
+    } else if ('codes' in result) {
+      setRecoveryCodes(result.codes);
+      setRecoveryPassword('');
+      mfaStatus.refetch();
+    }
+    setBusy(false);
+  }, [recoveryPassword]);
+
+  const copyRecoveryCodes = useCallback(() => {
+    if (recoveryCodes) {
+      navigator.clipboard.writeText(recoveryCodes.join('\n'));
+    }
+  }, [recoveryCodes]);
+
+  if (mfaStatus.isLoading) {
+    return (
+      <Loader active size="huge">
+        Loading MFA
+      </Loader>
+    );
+  }
+
+  const status = mfaStatus.data;
+
+  return (
+    <div className="mfa-manager">
+      <div className="section-header">Authenticator App</div>
+      <div className="stats">
+        <SectionError error={totpError} />
+        {status?.totpEnabled && !setupData && (
+          <>
+            <div className="stat">
+              <IconShieldCheck size={16} /> TOTP is enabled.
+            </div>
+            <div className="mfa-actions">
+              <Input
+                placeholder="Password to disable"
+                type="password"
+                value={totpPassword}
+                onChange={setTotpPassword}
+                onSubmit={totpPassword && !busy ? disableTotp : undefined}
+              />
+              <Button
+                warn
+                boxy
+                disabled={!totpPassword || busy}
+                onClick={disableTotp}
+              >
+                <IconX /> Disable
+              </Button>
+            </div>
+          </>
+        )}
+        {!status?.totpEnabled && !setupData && (
+          <>
+            <div className="stat">TOTP is not configured.</div>
+            <div className="mfa-actions">
+              <Input
+                placeholder="Password to set up"
+                type="password"
+                value={totpPassword}
+                onChange={setTotpPassword}
+                onSubmit={totpPassword && !busy ? startTotpSetup : undefined}
+              />
+              <Button
+                main
+                boxy
+                disabled={!totpPassword || busy}
+                onClick={startTotpSetup}
+              >
+                <IconShieldCheck /> Set Up
+              </Button>
+            </div>
+          </>
+        )}
+        {setupData && (
+          <div className="totp-setup">
+            <div className="stat">
+              Scan this QR code with your authenticator app:
+            </div>
+            <img
+              className="qr-code"
+              src={setupData.qrCode}
+              alt="TOTP QR Code"
+            />
+            <div className="stat manual-secret">
+              <b>Manual entry:</b> <code>{setupData.secret}</code>
+              <Button
+                icon
+                normal
+                data-tooltip="Copy secret"
+                onClick={() => navigator.clipboard.writeText(setupData.secret)}
+              >
+                <IconCopy />
+              </Button>
+            </div>
+            <div className="mfa-actions">
+              <Input
+                placeholder="6-digit code"
+                type="text"
+                value={verifyCode}
+                onChange={setVerifyCode}
+                onSubmit={verifyCode && !busy ? confirmTotp : undefined}
+              />
+              <Button
+                main
+                boxy
+                disabled={!verifyCode || busy}
+                onClick={confirmTotp}
+              >
+                <IconCheck /> Verify
+              </Button>
+              <Button
+                normal
+                boxy
+                onClick={() => {
+                  setSetupData(null);
+                  setTotpError('');
+                }}
+              >
+                <IconX /> Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {canWebAuthn && (
+        <>
+          <div className="section-header">Passkeys</div>
+          <div className="stats">
+            <SectionError error={passkeyError} />
+            {status?.passkeys?.length ? (
+              <div className="passkey-list">
+                {status.passkeys.map(p => (
+                  <div key={p.id} className="passkey-item">
+                    <span className="passkey-name">
+                      <IconFingerprint size={16} /> {p.name}
+                    </span>
+                    <span className="passkey-meta">
+                      Added {new Date(p.created).toLocaleDateString()}
+                    </span>
+                    <Button
+                      icon
+                      error
+                      disabled={busy}
+                      data-tooltip="Remove passkey"
+                      onClick={() => removePasskey(p.id)}
+                    >
+                      <IconTrash />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="stat">No passkeys registered.</div>
+            )}
+            <div className="mfa-actions">
+              <Input
+                placeholder="Passkey name"
+                type="text"
+                value={passkeyName}
+                onChange={setPasskeyName}
+              />
+              <Button main boxy disabled={busy} onClick={addPasskey}>
+                <IconPlus /> Add Passkey
+              </Button>
+            </div>
+            {status?.passkeys?.length ? (
+              <div className="mfa-actions">
+                <Input
+                  placeholder="Password to remove"
+                  type="password"
+                  value={passkeyPassword}
+                  onChange={setPasskeyPassword}
+                />
+              </div>
+            ) : (
+              <div className="stat note">
+                Passkeys may not work with IP addresses. Use a domain name for
+                reliable passkey support.
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <div className="section-header">Recovery Codes</div>
+      <div className="stats">
+        <SectionError error={recoveryError} />
+        {recoveryCodes ? (
+          <>
+            <div className="stat">
+              Save these codes. They will not be shown again.
+            </div>
+            <div className="recovery-grid">
+              {recoveryCodes.map((code, i) => (
+                <code key={i}>{code}</code>
+              ))}
+            </div>
+            <div className="mfa-actions">
+              <Button normal boxy onClick={copyRecoveryCodes}>
+                <IconCopy /> Copy
+              </Button>
+              <Button normal boxy onClick={() => setRecoveryCodes(null)}>
+                <IconCheck /> Done
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="stat">
+              {status?.hasRecoveryCodes
+                ? 'Recovery codes are configured.'
+                : 'No recovery codes generated.'}
+            </div>
+            <div className="mfa-actions">
+              <Input
+                placeholder="Password"
+                type="password"
+                value={recoveryPassword}
+                onChange={setRecoveryPassword}
+                onSubmit={
+                  recoveryPassword && !busy ? generateRecovery : undefined
+                }
+              />
+              <Button
+                warn={!!status?.hasRecoveryCodes}
+                main={!status?.hasRecoveryCodes}
+                boxy
+                disabled={!recoveryPassword || busy}
+                onClick={generateRecovery}
+              >
+                <IconKey />{' '}
+                {status?.hasRecoveryCodes ? 'Regenerate' : 'Generate'}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/views/users/PermissionEditor.tsx
+++ b/frontend/src/views/users/PermissionEditor.tsx
@@ -111,7 +111,9 @@ export const PermissionEditor = ({
   };
 
   const setScope = (scope: string, value: boolean) => {
-    const scopes = { ...perms.scopes, [scope]: value };
+    const scopes = { ...perms.scopes };
+    if (value) scopes[scope] = true;
+    else delete scopes[scope];
     onChange({ ...perms, scopes });
   };
 

--- a/frontend/src/views/users/PermissionEditor.tsx
+++ b/frontend/src/views/users/PermissionEditor.tsx
@@ -75,10 +75,12 @@ export const PermissionEditor = ({
   perms,
   onChange,
   defaultPerms,
+  disabled,
 }: {
   perms: PermissionSet;
   onChange: (p: PermissionSet) => void;
   defaultPerms?: PermissionSet | null;
+  disabled?: boolean;
 }) => {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
@@ -132,6 +134,7 @@ export const PermissionEditor = ({
           value={perms.root}
           options={ROOT_OPTIONS}
           onChange={setRoot}
+          disabled={disabled}
         />
       </div>
       {DOMAIN_ORDER.map(domain => {
@@ -159,7 +162,7 @@ export const PermissionEditor = ({
                 value={domainLevel ?? 'none'}
                 options={DOMAIN_OPTIONS}
                 onChange={v => setDomain(domain, v)}
-                disabled={rootLocked}
+                disabled={disabled || rootLocked}
               />
             </div>
             {isExpanded &&
@@ -198,7 +201,7 @@ export const PermissionEditor = ({
                       <Toggle
                         value={scopeVal}
                         onChange={v => setScope(scope, v)}
-                        disabled={domainLocked}
+                        disabled={disabled || domainLocked}
                       />
                     </div>
                   </div>

--- a/frontend/src/views/users/PermissionEditor.tsx
+++ b/frontend/src/views/users/PermissionEditor.tsx
@@ -1,10 +1,10 @@
-import { Toggle } from '@components';
+import { Input, Toggle } from '@components';
 import {
   IconCheck,
   IconChevronDown,
   IconChevronRight,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   DOMAIN_LABELS,
   DOMAIN_ORDER,
@@ -83,6 +83,10 @@ export const PermissionEditor = ({
   disabled?: boolean;
 }) => {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [search, setSearch] = useState('');
+
+  const searchLower = search.toLowerCase();
+  const hasSearch = searchLower.length > 0;
 
   const rootLocked = perms.root !== 'off';
 
@@ -126,23 +130,55 @@ export const PermissionEditor = ({
     return defaultPerms.scopes[scope] ?? false;
   };
 
+  const matchingDomains = useMemo(() => {
+    if (!hasSearch) return null;
+    const result: Record<string, Permission[]> = {};
+    for (const domain of DOMAIN_ORDER) {
+      const scopes = SCOPES_BY_DOMAIN[domain] ?? [];
+      const matches = scopes.filter(scope => {
+        const info = SCOPE_INFO[scope];
+        return (
+          scope.toLowerCase().includes(searchLower) ||
+          DOMAIN_LABELS[domain]?.toLowerCase().includes(searchLower) ||
+          info?.description?.toLowerCase().includes(searchLower)
+        );
+      });
+      if (matches.length > 0) result[domain] = matches;
+    }
+    return result;
+  }, [searchLower, hasSearch]);
+
   return (
     <div className="permission-editor">
-      <div className="perm-row root-row">
-        <span className="perm-label root-label">Everything</span>
-        <LevelPicker
-          value={perms.root}
-          options={ROOT_OPTIONS}
-          onChange={setRoot}
-          disabled={disabled}
+      <div className="perm-search">
+        <Input
+          type="text"
+          placeholder="Search Permissions..."
+          value={search}
+          onChange={setSearch}
         />
       </div>
+      {!hasSearch && (
+        <div className="perm-row root-row">
+          <span className="perm-label root-label">Everything</span>
+          <LevelPicker
+            value={perms.root}
+            options={ROOT_OPTIONS}
+            onChange={setRoot}
+            disabled={disabled}
+          />
+        </div>
+      )}
       {DOMAIN_ORDER.map(domain => {
         const domainLevel = perms.domains[domain];
         const domainLocked =
           rootLocked || domainLevel === 'all' || domainLevel === 'read';
-        const scopes = SCOPES_BY_DOMAIN[domain] ?? [];
-        const isExpanded = expanded[domain];
+        const allScopes = SCOPES_BY_DOMAIN[domain] ?? [];
+        const scopes = hasSearch
+          ? (matchingDomains?.[domain] ?? [])
+          : allScopes;
+        if (hasSearch && scopes.length === 0) return null;
+        const isExpanded = hasSearch || expanded[domain] !== false;
 
         return (
           <div className="perm-domain" key={domain}>

--- a/frontend/src/views/users/PermissionEditor.tsx
+++ b/frontend/src/views/users/PermissionEditor.tsx
@@ -1,0 +1,212 @@
+import { Toggle } from '@components';
+import {
+  IconCheck,
+  IconChevronDown,
+  IconChevronRight,
+} from '@tabler/icons-react';
+import { useState } from 'react';
+import {
+  DOMAIN_LABELS,
+  DOMAIN_ORDER,
+  SCOPE_INFO,
+  SCOPES_BY_DOMAIN,
+  type Permission,
+} from '../../permissions';
+
+export type DomainLevel = 'all' | 'read' | 'none';
+export type RootLevel = 'all' | 'read' | 'off';
+
+export interface PermissionSet {
+  root: RootLevel;
+  domains: Record<string, DomainLevel>;
+  scopes: Record<string, boolean>;
+}
+
+const ROOT_OPTIONS: { value: RootLevel; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'read', label: 'Read Only' },
+  { value: 'off', label: 'Manual' },
+];
+const DOMAIN_OPTIONS: { value: DomainLevel; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'read', label: 'Read Only' },
+  { value: 'none', label: 'Manual' },
+];
+
+function LevelPicker<T extends string>({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className={`level-picker ${disabled ? 'dimmed' : ''}`}>
+      {options.map((o, i) => (
+        <button
+          key={o.value}
+          className={[
+            'level-option',
+            value === o.value ? 'active' : '',
+            `level-${o.value}`,
+            i === 0 ? 'first' : '',
+            i === options.length - 1 ? 'last' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          onClick={() => {
+            if (disabled || value === o.value) return;
+            onChange(o.value);
+          }}
+          disabled={disabled}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export const PermissionEditor = ({
+  perms,
+  onChange,
+  defaultPerms,
+}: {
+  perms: PermissionSet;
+  onChange: (p: PermissionSet) => void;
+  defaultPerms?: PermissionSet | null;
+}) => {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const rootLocked = perms.root !== 'off';
+
+  const setRoot = (root: RootLevel) => {
+    if (root !== 'off') {
+      onChange({ ...perms, root, domains: {}, scopes: {} });
+    } else {
+      onChange({ ...perms, root });
+    }
+  };
+
+  const setDomain = (domain: string, level: DomainLevel) => {
+    const domains = { ...perms.domains };
+    const scopes = { ...perms.scopes };
+    if (level !== 'none') {
+      domains[domain] = level;
+      for (const s of SCOPES_BY_DOMAIN[domain] ?? []) delete scopes[s];
+    } else {
+      delete domains[domain];
+    }
+    onChange({ ...perms, domains, scopes });
+  };
+
+  const setScope = (scope: string, value: boolean) => {
+    const scopes = { ...perms.scopes, [scope]: value };
+    onChange({ ...perms, scopes });
+  };
+
+  const toggleExpanded = (domain: string) =>
+    setExpanded(e => ({ ...e, [domain]: !e[domain] }));
+
+  const effectiveForScope = (scope: Permission): boolean | null => {
+    if (!defaultPerms) return null;
+    const info = SCOPE_INFO[scope];
+    if (!info) return null;
+    if (defaultPerms.root === 'all') return true;
+    if (defaultPerms.root === 'read') return info.readOnly;
+    const dl = defaultPerms.domains[info.domain];
+    if (dl === 'all') return true;
+    if (dl === 'read') return info.readOnly;
+    return defaultPerms.scopes[scope] ?? false;
+  };
+
+  return (
+    <div className="permission-editor">
+      <div className="perm-row root-row">
+        <span className="perm-label root-label">Everything</span>
+        <LevelPicker
+          value={perms.root}
+          options={ROOT_OPTIONS}
+          onChange={setRoot}
+        />
+      </div>
+      {DOMAIN_ORDER.map(domain => {
+        const domainLevel = perms.domains[domain];
+        const domainLocked =
+          rootLocked || domainLevel === 'all' || domainLevel === 'read';
+        const scopes = SCOPES_BY_DOMAIN[domain] ?? [];
+        const isExpanded = expanded[domain];
+
+        return (
+          <div className="perm-domain" key={domain}>
+            <div className="perm-row domain-row">
+              <span
+                className="perm-label domain-label"
+                onClick={() => toggleExpanded(domain)}
+              >
+                {isExpanded ? (
+                  <IconChevronDown size={16} />
+                ) : (
+                  <IconChevronRight size={16} />
+                )}{' '}
+                {DOMAIN_LABELS[domain]}
+              </span>
+              <LevelPicker
+                value={domainLevel ?? 'none'}
+                options={DOMAIN_OPTIONS}
+                onChange={v => setDomain(domain, v)}
+                disabled={rootLocked}
+              />
+            </div>
+            {isExpanded &&
+              scopes.map((scope, i) => {
+                const info = SCOPE_INFO[scope];
+                const scopeVal = perms.scopes[scope] ?? false;
+                const inherited = effectiveForScope(scope);
+                return (
+                  <div
+                    className={`perm-row scope-row ${i % 2 === 0 ? 'even' : 'odd'}`}
+                    key={scope}
+                  >
+                    <div className="scope-info">
+                      <span className="scope-name">
+                        <span
+                          className={`scope-badge ${info?.readOnly ? 'read' : 'write'}`}
+                          data-tooltip={
+                            info?.readOnly ? 'Read-only' : 'Read/Write'
+                          }
+                        >
+                          {info?.readOnly ? 'R' : 'W'}
+                        </span>
+                        {scope.split('.').slice(1).join('.')}
+                      </span>
+                      <span className="scope-desc">{info?.description}</span>
+                    </div>
+                    <div className="scope-controls">
+                      {inherited === true && (
+                        <span
+                          className="inherited on"
+                          data-tooltip="Granted by defaults"
+                        >
+                          <IconCheck size={14} />
+                        </span>
+                      )}
+                      <Toggle
+                        value={scopeVal}
+                        onChange={v => setScope(scope, v)}
+                        disabled={domainLocked}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/views/users/UserInspector.tsx
+++ b/frontend/src/views/users/UserInspector.tsx
@@ -1,0 +1,269 @@
+import type { GetUsersRes } from '@backend/api';
+import {
+  Button,
+  Footer,
+  Loader,
+  NavBar,
+  Scroll,
+  useConfirm,
+} from '@components';
+import { useHasScope } from '@hooks';
+import { useStore } from '@nanostores/react';
+import { IconBan, IconDeviceFloppy, IconTrash } from '@tabler/icons-react';
+import { duration } from '@utils';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useRoute } from 'wouter';
+import { Permissions } from '../../permissions';
+import { $user, $usersRefresh } from '../../stores/user';
+import { trpc } from '../../trpc';
+import { PermissionEditor, type PermissionSet } from './PermissionEditor';
+
+export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
+  const [_match, params] = useRoute('/users/:id');
+  const [_loc, navigate] = useLocation();
+  const myUser = useStore($user);
+
+  const canEditPerms = useHasScope(Permissions.UserPermissions);
+  const canBan = useHasScope(Permissions.UserBan);
+  const canDelete = useHasScope(Permissions.UserDelete);
+
+  const isSelfMode = !!selfUser;
+  const selectedUsername = selfUser ?? params?.id ?? '';
+
+  const users = trpc.user.list.useQuery(undefined, {
+    enabled: !isSelfMode,
+  });
+  const selfQuery = trpc.user.self.useQuery(undefined, {
+    enabled: isSelfMode,
+  });
+
+  const user = useMemo(() => {
+    if (isSelfMode) {
+      return selfQuery.data ?? null;
+    }
+    if (!users.data) return null;
+    return (
+      users.data.users.find(
+        (u: GetUsersRes['users'][number]) => u.username === selectedUsername,
+      ) ?? null
+    );
+  }, [isSelfMode, selfQuery.data, users.data, selectedUsername]);
+
+  const loading = isSelfMode ? selfQuery.isLoading : users.isLoading;
+
+  const defaultPermsQuery = trpc.user.defaultPermissions.get.useQuery(
+    undefined,
+    { enabled: canEditPerms },
+  );
+  const permsMutation = trpc.user.permissions.useMutation();
+  const banMutation = trpc.user.ban.useMutation();
+  const deleteMutation = trpc.user.delete.useMutation();
+  const banConfirm = useConfirm();
+  const deleteConfirm = useConfirm();
+
+  const [editPerms, setEditPerms] = useState<PermissionSet | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      const root = user.permissions?.root;
+      setEditPerms({
+        root: root === 'all' || root === 'read' ? root : 'off',
+        domains: (user.permissions?.domains as PermissionSet['domains']) ?? {},
+        scopes: (user.permissions?.scopes as PermissionSet['scopes']) ?? {},
+      });
+    } else {
+      setEditPerms(null);
+    }
+  }, [user?.username, user?.permissions]);
+
+  useEffect(() => {
+    if (!isSelfMode && !loading && !user && selectedUsername) {
+      navigate('/users');
+    }
+  }, [isSelfMode, loading, user, selectedUsername]);
+
+  const savePerms = useCallback(async () => {
+    if (!editPerms || !selectedUsername) return;
+    setSaving(true);
+    try {
+      const err = await permsMutation.mutateAsync({
+        username: selectedUsername,
+        permissions: editPerms,
+      });
+      if (err) console.error('Failed to save permissions:', err);
+      else if (isSelfMode) selfQuery.refetch();
+      else users.refetch();
+    } catch (e) {
+      console.error('Failed to save permissions:', e);
+    }
+    setSaving(false);
+  }, [editPerms, selectedUsername]);
+
+  const dirty = useMemo(() => {
+    if (!editPerms || !user?.permissions) return false;
+    return JSON.stringify(editPerms) !== JSON.stringify(user.permissions);
+  }, [editPerms, user?.permissions]);
+
+  const handleBan = async (banned: boolean) => {
+    const action = banned ? 'Disable' : 'Re-enable';
+    if (
+      !(await banConfirm.prompt(
+        <>
+          <p>
+            {action} user <b>{selectedUsername}</b>?
+          </p>
+          <p>
+            {banned
+              ? 'Disabled users cannot sign in to the web UI.'
+              : 'This will allow the user to sign in again.'}
+          </p>
+        </>,
+      ))
+    )
+      return;
+    const err = await banMutation.mutateAsync({
+      username: selectedUsername,
+      banned,
+    });
+    if (err) console.error('Failed to ban user:', err);
+    else users.refetch();
+  };
+
+  const handleDelete = async () => {
+    if (
+      !(await deleteConfirm.prompt(
+        <>
+          <p>
+            Permanently delete user <b>{selectedUsername}</b>?
+          </p>
+          <p>
+            This will remove the account and all of its permissions. This action
+            cannot be undone.
+          </p>
+        </>,
+      ))
+    )
+      return;
+    const err = await deleteMutation.mutateAsync({
+      username: selectedUsername,
+    });
+    if (err) console.error('Failed to delete user:', err);
+    else {
+      navigate('/users');
+      users.refetch();
+      $usersRefresh.set($usersRefresh.get() + 1);
+    }
+  };
+
+  const isSelf =
+    (myUser?.username || 'Admin') === (selectedUsername || 'Admin');
+  const showActions = user && !user.isOwner && !isSelf && (canBan || canDelete);
+
+  const defaultPerms = defaultPermsQuery.data
+    ? ({
+        root: defaultPermsQuery.data.root,
+        domains: defaultPermsQuery.data.domains,
+        scopes: defaultPermsQuery.data.scopes,
+      } as PermissionSet)
+    : null;
+
+  const now = Date.now();
+
+  return (
+    <>
+      <div className="player-inspector-container">
+        <NavBar attached>
+          {user?.username || (isSelfMode ? 'Account' : 'SELECT A USER')}
+          <span style={{ flex: 1 }} />
+          {user && canEditPerms && !user.isOwner && (
+            <Button
+              normal
+              disabled={saving || !dirty}
+              onClick={savePerms}
+              data-tooltip="Save Permissions"
+            >
+              <IconDeviceFloppy />
+              Save
+            </Button>
+          )}
+        </NavBar>
+        <div className={`player-inspector ${showActions ? 'has-footer' : ''}`}>
+          <div className="player-view">
+            <Loader active={loading} size="huge">
+              Loading User
+            </Loader>
+            <div className="player-info">
+              {!loading && user && (
+                <Scroll>
+                  <div className="stats">
+                    <div className="stat">
+                      <b>Username:</b> {user.username || 'Admin'}
+                    </div>
+                    <div className="stat">
+                      <b>Owner:</b> {user.isOwner ? 'Yes' : 'No'}
+                    </div>
+                    <div className="stat">
+                      <b>Disabled:</b> {user.isBanned ? 'Yes' : 'No'}
+                    </div>
+                    <div className="stat">
+                      <b>Last Active:</b>{' '}
+                      {user.lastOnline
+                        ? duration(now - user.lastOnline) + ' ago'
+                        : 'Never'}
+                    </div>
+                    <div className="stat">
+                      <b>Created:</b> {duration(now - user.created)} ago
+                    </div>
+                  </div>
+                  {canEditPerms && !user.isOwner && editPerms && (
+                    <>
+                      <div className="section-header">Permissions</div>
+                      <PermissionEditor
+                        perms={editPerms}
+                        onChange={setEditPerms}
+                        defaultPerms={defaultPerms}
+                      />
+                    </>
+                  )}
+                  {user.isOwner && (
+                    <>
+                      <div className="section-header">Permissions</div>
+                      <div className="stats">
+                        <div className="stat">Owner has all permissions.</div>
+                      </div>
+                    </>
+                  )}
+                </Scroll>
+              )}
+            </div>
+          </div>
+        </div>
+        {showActions && (
+          <Footer attached>
+            {canBan && (
+              <Button
+                boxy
+                normal={!user.isBanned}
+                warn={!!user.isBanned}
+                onClick={() => handleBan(!user.isBanned)}
+              >
+                <IconBan />
+                {user.isBanned ? 'Re-enable' : 'Disable'}
+              </Button>
+            )}
+            <span style={{ flex: 1 }} />
+            {canDelete && (
+              <Button boxy error onClick={handleDelete}>
+                <IconTrash />
+                Delete
+              </Button>
+            )}
+          </Footer>
+        )}
+      </div>
+      {banConfirm.children}
+      {deleteConfirm.children}
+    </>
+  );
+};

--- a/frontend/src/views/users/UserInspector.tsx
+++ b/frontend/src/views/users/UserInspector.tsx
@@ -1,21 +1,43 @@
-import type { GetUsersRes } from '@backend/api';
 import {
   Button,
+  Dimmer,
   Footer,
+  Header,
+  Input,
   Loader,
+  Modal,
   NavBar,
+  PopoutContent,
   Scroll,
   useConfirm,
 } from '@components';
 import { useHasScope } from '@hooks';
 import { useStore } from '@nanostores/react';
-import { IconBan, IconDeviceFloppy, IconTrash } from '@tabler/icons-react';
+import {
+  IconBan,
+  IconCaretDown,
+  IconCaretUp,
+  IconDeviceFloppy,
+  IconKey,
+  IconShieldOff,
+  IconTrash,
+  IconX,
+} from '@tabler/icons-react';
 import { duration } from '@utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useRoute } from 'wouter';
 import { Permissions } from '../../permissions';
 import { $user, $usersRefresh } from '../../stores/user';
-import { trpc } from '../../trpc';
+import { trpc, type RouterOutputs } from '../../trpc';
+
+type UserFromList = RouterOutputs['user']['list']['users'][number];
+type UserFromSelf = RouterOutputs['user']['self'];
+type UserData = (UserFromList | UserFromSelf) & {
+  totpEnabled?: boolean;
+  passkeyCount?: number;
+};
+
+import { MfaManager } from './MfaManager';
 import { PermissionEditor, type PermissionSet } from './PermissionEditor';
 
 export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
@@ -26,6 +48,9 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
   const canEditPerms = useHasScope(Permissions.UserPermissions);
   const canBan = useHasScope(Permissions.UserBan);
   const canDelete = useHasScope(Permissions.UserDelete);
+  const canPasswd = useHasScope(Permissions.UserPasswd);
+  const canReadMfa = useHasScope(Permissions.UserReadMfa);
+  const canResetMfa = useHasScope(Permissions.UserResetMfa);
 
   const isSelfMode = !!selfUser;
   const selectedUsername = selfUser ?? params?.id ?? '';
@@ -37,16 +62,12 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
     enabled: isSelfMode,
   });
 
-  const user = useMemo(() => {
+  const user = useMemo((): UserData | null => {
     if (isSelfMode) {
       return selfQuery.data ?? null;
     }
     if (!users.data) return null;
-    return (
-      users.data.users.find(
-        (u: GetUsersRes['users'][number]) => u.username === selectedUsername,
-      ) ?? null
-    );
+    return users.data.users.find(u => u.username === selectedUsername) ?? null;
   }, [isSelfMode, selfQuery.data, users.data, selectedUsername]);
 
   const loading = isSelfMode ? selfQuery.isLoading : users.isLoading;
@@ -58,11 +79,21 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
   const permsMutation = trpc.user.permissions.useMutation();
   const banMutation = trpc.user.ban.useMutation();
   const deleteMutation = trpc.user.delete.useMutation();
+  const passwdMutation = trpc.user.passwd.useMutation();
+  const resetMfaMutation = trpc.user.resetMfa.useMutation();
   const banConfirm = useConfirm();
   const deleteConfirm = useConfirm();
+  const resetMfaConfirm = useConfirm();
 
   const [editPerms, setEditPerms] = useState<PermissionSet | null>(null);
   const [saving, setSaving] = useState(false);
+  const [permError, setPermError] = useState('');
+  const [showActionsMenu, setShowActionsMenu] = useState(false);
+  const [showPasswd, setShowPasswd] = useState(false);
+  const [passwdLoading, setPasswdLoading] = useState(false);
+  const [passwdError, setPasswdError] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmNewPassword, setConfirmNewPassword] = useState('');
 
   useEffect(() => {
     if (user) {
@@ -83,19 +114,24 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
     }
   }, [isSelfMode, loading, user, selectedUsername]);
 
+  const utils = trpc.useUtils();
   const savePerms = useCallback(async () => {
     if (!editPerms || !selectedUsername) return;
     setSaving(true);
+    setPermError('');
     try {
       const err = await permsMutation.mutateAsync({
         username: selectedUsername,
         permissions: editPerms,
       });
-      if (err) console.error('Failed to save permissions:', err);
-      else if (isSelfMode) selfQuery.refetch();
-      else users.refetch();
-    } catch (e) {
-      console.error('Failed to save permissions:', e);
+      if (err) {
+        setPermError(err);
+      } else {
+        await utils.user.list.refetch();
+        if (isSelfMode) await selfQuery.refetch();
+      }
+    } catch (e: any) {
+      setPermError(e?.message || 'Failed to save permissions');
     }
     setSaving(false);
   }, [editPerms, selectedUsername]);
@@ -156,9 +192,56 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
     }
   };
 
+  const handleResetMfa = async () => {
+    if (
+      !(await resetMfaConfirm.prompt(
+        <>
+          <p>
+            Reset MFA for <b>{selectedUsername}</b>?
+          </p>
+          <p>This will clear TOTP, passkeys, and recovery codes.</p>
+        </>,
+      ))
+    )
+      return;
+    const err = await resetMfaMutation.mutateAsync({
+      username: selectedUsername,
+    });
+    if (err) console.error('Failed to reset MFA:', err);
+    else if (isSelfMode) selfQuery.refetch();
+    else users.refetch();
+  };
+
+  const handlePasswd = async () => {
+    setPasswdError('');
+    if (newPassword !== confirmNewPassword) return;
+    setPasswdLoading(true);
+    try {
+      const err = await passwdMutation.mutateAsync({
+        username: selectedUsername,
+        password: newPassword,
+      });
+      setPasswdLoading(false);
+      if (err) {
+        setPasswdError(err);
+      } else {
+        setShowPasswd(false);
+        setNewPassword('');
+        setConfirmNewPassword('');
+      }
+    } catch {
+      setPasswdLoading(false);
+    }
+  };
+
   const isSelf =
     (myUser?.username || 'Admin') === (selectedUsername || 'Admin');
-  const showActions = user && !user.isOwner && !isSelf && (canBan || canDelete);
+  const hasMfa = user && (user.totpEnabled || (user.passkeyCount ?? 0) > 0);
+  const hasAdminActions =
+    user &&
+    !user.isOwner &&
+    !isSelf &&
+    (canBan || canDelete || canPasswd || (canResetMfa && hasMfa));
 
   const defaultPerms = defaultPermsQuery.data
     ? ({
@@ -188,7 +271,7 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
             </Button>
           )}
         </NavBar>
-        <div className={`player-inspector ${showActions ? 'has-footer' : ''}`}>
+        <div className="player-inspector">
           <div className="player-view">
             <Loader active={loading} size="huge">
               Loading User
@@ -215,10 +298,28 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
                     <div className="stat">
                       <b>Created:</b> {duration(now - user.created)} ago
                     </div>
+                    {!isSelf && canReadMfa && (
+                      <div className="stat">
+                        <b>MFA:</b>{' '}
+                        {user.totpEnabled || (user.passkeyCount ?? 0) > 0
+                          ? [
+                              user.totpEnabled && 'TOTP',
+                              (user.passkeyCount ?? 0) > 0 &&
+                                `${user.passkeyCount ?? 0} passkey(s)`,
+                            ]
+                              .filter(Boolean)
+                              .join(' + ')
+                          : 'Not configured'}
+                      </div>
+                    )}
                   </div>
+                  {isSelfMode && <MfaManager />}
                   {canEditPerms && !user.isOwner && editPerms && (
                     <>
                       <div className="section-header">Permissions</div>
+                      {permError && (
+                        <div className="perm-error">{permError}</div>
+                      )}
                       <PermissionEditor
                         perms={editPerms}
                         onChange={setEditPerms}
@@ -229,9 +330,11 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
                   {user.isOwner && (
                     <>
                       <div className="section-header">Permissions</div>
-                      <div className="stats">
-                        <div className="stat">Owner has all permissions.</div>
-                      </div>
+                      <PermissionEditor
+                        perms={{ root: 'all', domains: {}, scopes: {} }}
+                        onChange={() => {}}
+                        disabled
+                      />
                     </>
                   )}
                 </Scroll>
@@ -239,31 +342,139 @@ export const UserInspector = ({ selfUser }: { selfUser?: string }) => {
             </div>
           </div>
         </div>
-        {showActions && (
+        {hasAdminActions && (
           <Footer attached>
-            {canBan && (
-              <Button
-                boxy
-                normal={!user.isBanned}
-                warn={!!user.isBanned}
-                onClick={() => handleBan(!user.isBanned)}
-              >
-                <IconBan />
-                {user.isBanned ? 'Re-enable' : 'Disable'}
-              </Button>
-            )}
             <span style={{ flex: 1 }} />
-            {canDelete && (
-              <Button boxy error onClick={handleDelete}>
-                <IconTrash />
-                Delete
+            <div className="widgets-container">
+              <Button
+                normal
+                boxy
+                onClick={() => setShowActionsMenu(!showActionsMenu)}
+              >
+                {showActionsMenu ? <IconCaretDown /> : <IconCaretUp />}
+                Actions
               </Button>
-            )}
+              <div
+                className="widgets-list widgets-list-up"
+                style={{ display: showActionsMenu ? 'block' : 'none' }}
+              >
+                {canPasswd && (
+                  <Button
+                    info
+                    onClick={() => {
+                      setShowActionsMenu(false);
+                      setShowPasswd(true);
+                    }}
+                  >
+                    <IconKey />
+                    Change Password
+                  </Button>
+                )}
+                {canBan && (
+                  <Button
+                    normal={!user.isBanned}
+                    warn={!!user.isBanned}
+                    onClick={() => {
+                      setShowActionsMenu(false);
+                      handleBan(!user.isBanned);
+                    }}
+                  >
+                    <IconBan />
+                    {user.isBanned ? 'Re-enable' : 'Disable'}
+                  </Button>
+                )}
+                {canResetMfa && hasMfa && (
+                  <Button
+                    warn
+                    onClick={() => {
+                      setShowActionsMenu(false);
+                      handleResetMfa();
+                    }}
+                  >
+                    <IconShieldOff />
+                    Reset MFA
+                  </Button>
+                )}
+                {canDelete && (
+                  <Button
+                    error
+                    onClick={() => {
+                      setShowActionsMenu(false);
+                      handleDelete();
+                    }}
+                  >
+                    <IconTrash />
+                    Delete
+                  </Button>
+                )}
+              </div>
+            </div>
           </Footer>
         )}
       </div>
       {banConfirm.children}
       {deleteConfirm.children}
+      {resetMfaConfirm.children}
+      <Dimmer visible={showPasswd}>
+        <Loader active={passwdLoading} size="huge">
+          Submitting
+        </Loader>
+        <Modal visible={!passwdLoading}>
+          <Header>Change Password</Header>
+          <PopoutContent>
+            <p>
+              Set a new password for <b>{selectedUsername}</b>.
+            </p>
+            {passwdError && (
+              <p style={{ color: 'red' }}>Error: {passwdError}</p>
+            )}
+          </PopoutContent>
+          <div className="popout-inputs">
+            <Input
+              placeholder="new password"
+              type="password"
+              value={newPassword}
+              onChange={setNewPassword}
+            />
+            <Input
+              placeholder="confirm new password"
+              type="password"
+              value={confirmNewPassword}
+              onChange={setConfirmNewPassword}
+              onSubmit={
+                newPassword.length && confirmNewPassword === newPassword
+                  ? handlePasswd
+                  : undefined
+              }
+            />
+          </div>
+          <Footer>
+            <Button
+              main
+              disabled={
+                !newPassword.length || confirmNewPassword !== newPassword
+              }
+              onClick={handlePasswd}
+            >
+              <IconKey />
+              Update
+            </Button>
+            <div style={{ flex: 1 }} />
+            <Button
+              normal
+              onClick={() => {
+                setShowPasswd(false);
+                setNewPassword('');
+                setConfirmNewPassword('');
+                setPasswdError('');
+              }}
+            >
+              <IconX />
+              Cancel
+            </Button>
+          </Footer>
+        </Modal>
+      </Dimmer>
     </>
   );
 };

--- a/frontend/src/views/users/UserList.tsx
+++ b/frontend/src/views/users/UserList.tsx
@@ -30,26 +30,25 @@ import {
   IconUserPlus,
   IconX,
 } from '@tabler/icons-react';
-import { useHasScope } from '@hooks';
+import { useHasScope, useRequireScope } from '@hooks';
 import { duration, logout } from '@utils';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { Route, Switch, useLocation, useRoute } from 'wouter';
 import { UserInspector } from './UserInspector';
 import { DefaultPermissions } from './DefaultPermissions';
-import { Domains, Permissions } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { $omeggaData, $user, $usersRefresh } from '../../stores/user';
 import { trpc } from '../../trpc';
 
-const ACTION_CHANGE_PASSWORD = 'Change Password';
 const ACTION_ENABLE_USERS = 'Enable Users';
 const ACTION_ADD_USER = 'Add User';
 const ACTION_DEFAULT_PERMS = 'Default Permissions';
 
 export const UserList = () => {
+  const canAccess = useRequireScope(Permissions.UserList);
   const userless = useStore($omeggaData)?.userless;
   const myUser = useStore($user);
 
-  const canList = useHasScope(Permissions.UserList);
   const canCreate = useHasScope(Permissions.UserCreate);
   const canEditPerms = useHasScope(Permissions.UserPermissions);
 
@@ -64,8 +63,8 @@ export const UserList = () => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const [showCredentials, setShowCredentials] = useState(false);
   const [showCreateUser, setShowCreateUser] = useState(false);
+  const [showEnableUsers, setShowEnableUsers] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
 
   const [_location, navigate] = useLocation();
@@ -73,22 +72,21 @@ export const UserList = () => {
 
   const utils = trpc.useUtils();
   const createMutation = trpc.user.create.useMutation();
-  const passwdMutation = trpc.user.passwd.useMutation();
 
   const [showActions, setShowActions] = useState(false);
 
-  const openCredentials = () => {
+  const openEnableUsers = () => {
     setShowActions(false);
-    setShowCredentials(true);
+    setShowEnableUsers(true);
     setShowCreateUser(false);
-    if (!userless) setUsername(myUser?.username ?? '');
+    setUsername('');
     setError('');
   };
 
   const openCreateUser = () => {
     setShowActions(false);
     setShowCreateUser(true);
-    setShowCredentials(false);
+    setShowEnableUsers(false);
     setUsername('');
     setError('');
   };
@@ -136,15 +134,11 @@ export const UserList = () => {
     getUsers();
   }, [usersRefresh]);
 
-  // update table sort direction
   const setSort = (s: string) => {
-    // flip direction if it's the same column
     if (s == sort) {
       setDirection(d => d * -1);
     } else {
-      // otherwise, use the new column
       query.current.sort = s;
-      // sort only name ascending on first click, all metrics are descending
       setDirection(s === 'name' ? 1 : -1);
     }
     getUsers();
@@ -158,7 +152,7 @@ export const UserList = () => {
 
   const hideModals = () => {
     setShowCreateUser(false);
-    setShowCredentials(false);
+    setShowEnableUsers(false);
     setUsername('');
     setError('');
     setPassword('');
@@ -171,23 +165,15 @@ export const UserList = () => {
     setModalLoading(true);
     let err = '';
     try {
-      if (showCredentials && !userless) {
-        err = await passwdMutation.mutateAsync({
-          username: myUser?.username ?? '',
-          password,
-        });
-      } else {
-        err = await createMutation.mutateAsync({ username, password });
-      }
+      err = await createMutation.mutateAsync({ username, password });
       setModalLoading(false);
       if (!err) {
-        if (showCredentials && userless) logout();
+        if (showEnableUsers) logout();
         else {
-          const wasCreate = showCreateUser;
           const createdName = username;
           hideModals();
           await getUsers();
-          if (wasCreate) navigate(`/users/${createdName}`);
+          navigate(`/users/${createdName}`);
         }
         return;
       }
@@ -198,80 +184,16 @@ export const UserList = () => {
   };
 
   const ok = useMemo(() => {
-    const nameOk = username.length !== 0 || !(showCredentials && !userless);
-    return username.match(/^\w{0,32}$/) && nameOk && password.length !== 0;
-  }, [username, password, showCredentials, userless]);
-
-  if (!canList) {
     return (
-      <>
-        <NavHeader title="Account">
-          <div className="widgets-container">
-            <Button normal boxy onClick={() => setShowActions(!showActions)}>
-              {showActions ? <IconCaretUp /> : <IconCaretDown />}
-              Actions
-            </Button>
-            <div
-              className="widgets-list"
-              style={{ display: showActions ? 'block' : 'none' }}
-            >
-              <Button info onClick={openCredentials}>
-                <IconLock />
-                {ACTION_CHANGE_PASSWORD}
-              </Button>
-            </div>
-          </div>
-        </NavHeader>
-        <PageContent>
-          <SideNav />
-          <div className="generic-container players-container">
-            <UserInspector selfUser={myUser?.username} />
-          </div>
-          <Dimmer visible={showCredentials}>
-            <Loader active={modalLoading} size="huge">
-              Submitting
-            </Loader>
-            <Modal visible={!modalLoading}>
-              <Header>Update Credentials</Header>
-              <PopoutContent>
-                <p>Updating credentials for user "{username}"</p>
-                {error && <p style={{ color: 'red' }}>Error: {error}</p>}
-              </PopoutContent>
-              <div className="popout-inputs">
-                <Input
-                  placeholder="password"
-                  type="password"
-                  value={password}
-                  onChange={p => setPassword(p)}
-                />
-                <Input
-                  placeholder="confirm password"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={p => setConfirmPassword(p)}
-                />
-              </div>
-              <Footer>
-                <Button
-                  main
-                  disabled={!password.length || confirmPassword !== password}
-                  onClick={() => submit()}
-                >
-                  <IconLock />
-                  Update
-                </Button>
-                <div style={{ flex: 1 }} />
-                <Button normal onClick={hideModals}>
-                  <IconX />
-                  Cancel
-                </Button>
-              </Footer>
-            </Modal>
-          </Dimmer>
-        </PageContent>
-      </>
+      username.match(/^\w{0,32}$/) &&
+      username.length !== 0 &&
+      password.length !== 0
     );
-  }
+  }, [username, password]);
+
+  if (!canAccess) return null;
+
+  const hasDropdownActions = userless || (!userless && canCreate);
 
   return (
     <>
@@ -287,37 +209,41 @@ export const UserList = () => {
             {ACTION_DEFAULT_PERMS}
           </Button>
         )}
-        <div className="widgets-container">
-          <Button normal boxy onClick={() => setShowActions(!showActions)}>
-            {showActions ? <IconCaretUp /> : <IconCaretDown />}
-            Actions
-          </Button>
-          <div
-            className="widgets-list"
-            style={{ display: showActions ? 'block' : 'none' }}
-          >
-            {!userless && canEditPerms && (
-              <Button
-                normal
-                className="default-perms-dropdown hidden"
-                onClick={openDefaultPerms}
-              >
-                <IconShield />
-                {ACTION_DEFAULT_PERMS}
-              </Button>
-            )}
-            <Button info onClick={openCredentials}>
-              <IconLock />
-              {userless ? ACTION_ENABLE_USERS : ACTION_CHANGE_PASSWORD}
+        {hasDropdownActions && (
+          <div className="widgets-container">
+            <Button normal boxy onClick={() => setShowActions(!showActions)}>
+              {showActions ? <IconCaretUp /> : <IconCaretDown />}
+              Actions
             </Button>
-            {!userless && canCreate && (
-              <Button main onClick={openCreateUser}>
-                <IconUserPlus />
-                {ACTION_ADD_USER}
-              </Button>
-            )}
+            <div
+              className="widgets-list"
+              style={{ display: showActions ? 'block' : 'none' }}
+            >
+              {!userless && canEditPerms && (
+                <Button
+                  normal
+                  className="default-perms-dropdown hidden"
+                  onClick={openDefaultPerms}
+                >
+                  <IconShield />
+                  {ACTION_DEFAULT_PERMS}
+                </Button>
+              )}
+              {userless && (
+                <Button info onClick={openEnableUsers}>
+                  <IconLock />
+                  {ACTION_ENABLE_USERS}
+                </Button>
+              )}
+              {!userless && canCreate && (
+                <Button main onClick={openCreateUser}>
+                  <IconUserPlus />
+                  {ACTION_ADD_USER}
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </NavHeader>
       <PageContent>
         <SideNav />
@@ -429,9 +355,7 @@ export const UserList = () => {
                   icon
                   normal
                   disabled={page === 0}
-                  onClick={() => {
-                    setPage(0);
-                  }}
+                  onClick={() => setPage(0)}
                 >
                   <IconArrowBarToLeft />
                 </Button>
@@ -455,9 +379,7 @@ export const UserList = () => {
                   icon
                   normal
                   disabled={page >= pages - 1}
-                  onClick={() =>
-                    setPage(p => Math.min(users.length - 1, p + 1))
-                  }
+                  onClick={() => setPage(p => Math.min(pages - 1, p + 1))}
                 >
                   <IconArrowRight />
                 </Button>
@@ -465,7 +387,7 @@ export const UserList = () => {
                   icon
                   normal
                   disabled={page >= pages - 1}
-                  onClick={() => setPage(users.length - 1)}
+                  onClick={() => setPage(pages - 1)}
                 >
                   <IconArrowBarToRight />
                 </Button>
@@ -485,16 +407,16 @@ export const UserList = () => {
               </div>
             </Route>
           </Switch>
-          <Dimmer visible={showCredentials || showCreateUser}>
+          <Dimmer visible={showCreateUser || showEnableUsers}>
             <Loader active={modalLoading} size="huge">
               Submitting
             </Loader>
             <Modal visible={!modalLoading}>
               <Header>
-                {showCreateUser ? 'Create New User' : 'Update Credentials'}
+                {showEnableUsers ? 'Enable Users' : 'Create New User'}
               </Header>
               <PopoutContent>
-                {userless && (
+                {showEnableUsers && (
                   <>
                     <p>
                       This will require you to enter a password when you sign
@@ -502,9 +424,6 @@ export const UserList = () => {
                     </p>
                     <p>This action cannot be undone.</p>
                   </>
-                )}
-                {!userless && showCredentials && (
-                  <p>Updating credentials for user "{username}"</p>
                 )}
                 {showCreateUser && (
                   <p>
@@ -515,14 +434,12 @@ export const UserList = () => {
                 {error && <p style={{ color: 'red' }}>Error: {error}</p>}
               </PopoutContent>
               <div className="popout-inputs">
-                {(userless || showCreateUser) && (
-                  <Input
-                    placeholder="username"
-                    type="text"
-                    value={username}
-                    onChange={u => setUsername(u)}
-                  />
-                )}
+                <Input
+                  placeholder="username"
+                  type="text"
+                  value={username}
+                  onChange={u => setUsername(u)}
+                />
                 <Input
                   placeholder="password"
                   type="password"
@@ -534,6 +451,9 @@ export const UserList = () => {
                   type="password"
                   value={confirmPassword}
                   onChange={p => setConfirmPassword(p)}
+                  onSubmit={
+                    ok && confirmPassword === password ? submit : undefined
+                  }
                 />
               </div>
               <Footer>
@@ -542,9 +462,8 @@ export const UserList = () => {
                   disabled={!ok || confirmPassword !== password}
                   onClick={() => submit()}
                 >
-                  {showCreateUser && <IconUserPlus />}
-                  {!showCreateUser && <IconLock />}
-                  {showCreateUser ? 'Add' : 'Update'}
+                  <IconUserPlus />
+                  {showEnableUsers ? 'Enable' : 'Add'}
                 </Button>
                 <div style={{ flex: 1 }} />
                 <Button normal onClick={hideModals}>

--- a/frontend/src/views/users/UserList.tsx
+++ b/frontend/src/views/users/UserList.tsx
@@ -14,6 +14,7 @@ import {
   Scroll,
   SideNav,
   SortIcons,
+  useConfirm,
 } from '@components';
 import { useStore } from '@nanostores/react';
 import {
@@ -21,9 +22,11 @@ import {
   IconArrowBarToRight,
   IconArrowLeft,
   IconArrowRight,
+  IconBan,
   IconCirclePlus,
   IconLock,
   IconRotate,
+  IconTrash,
   IconUserPlus,
   IconX,
 } from '@tabler/icons-react';
@@ -61,6 +64,10 @@ export const UserList = () => {
   const utils = trpc.useUtils();
   const createMutation = trpc.user.create.useMutation();
   const passwdMutation = trpc.user.passwd.useMutation();
+  const banMutation = trpc.user.ban.useMutation();
+  const deleteMutation = trpc.user.delete.useMutation();
+  const banConfirm = useConfirm();
+  const deleteConfirm = useConfirm();
 
   const query = useRef({
     page: 0,
@@ -189,6 +196,27 @@ export const UserList = () => {
     setError(err);
   };
 
+  const handleBan = async (username: string, currentlyBanned: boolean) => {
+    const action = currentlyBanned ? 're-enable' : 'disable';
+    if (!(await banConfirm.prompt(`${action} user "${username}"`))) return;
+    const err = await banMutation.mutateAsync({
+      username,
+      banned: !currentlyBanned,
+    });
+    if (err) setError(err);
+    else getUsers();
+  };
+
+  const handleDelete = async (username: string) => {
+    if (
+      !(await deleteConfirm.prompt(`permanently delete user "${username}"`))
+    )
+      return;
+    const err = await deleteMutation.mutateAsync({ username });
+    if (err) setError(err);
+    else getUsers();
+  };
+
   const ok = useMemo(() => {
     const nameOk = username.length !== 0 || !(showCredentials && !userless);
     return username.match(/^\w{0,32}$/) && nameOk && password.length !== 0;
@@ -287,6 +315,11 @@ export const UserList = () => {
                           />
                         </span>
                       </th>
+                      {!userless && myUser?.isOwner && (
+                        <th style={{ width: 1 }}>
+                          <span>Actions</span>
+                        </th>
+                      )}
                     </tr>
                   </thead>
                   <tbody>
@@ -297,6 +330,11 @@ export const UserList = () => {
                         key={u.username}
                       >
                         <td>
+                          {u.isBanned && (
+                            <span className="ban">
+                              <IconBan size={14} />{' '}
+                            </span>
+                          )}
                           {u.username || 'Admin'}{' '}
                           {(u.username || 'Admin') ===
                             (myUser?.username || 'Admin') && (
@@ -317,6 +355,41 @@ export const UserList = () => {
                         >
                           {duration(u.createdAgo)}
                         </td>
+                        {!userless && myUser?.isOwner && (
+                          <td
+                            style={{ whiteSpace: 'nowrap' }}
+                            onClick={e => e.stopPropagation()}
+                          >
+                            {!u.isOwner &&
+                              u.username !== myUser?.username && (
+                                <>
+                                  <Button
+                                    icon
+                                    normal={!u.isBanned}
+                                    warn={!!u.isBanned}
+                                    data-tooltip={
+                                      u.isBanned
+                                        ? 'Re-enable user'
+                                        : 'Disable user'
+                                    }
+                                    onClick={() =>
+                                      handleBan(u.username, !!u.isBanned)
+                                    }
+                                  >
+                                    <IconBan />
+                                  </Button>
+                                  <Button
+                                    icon
+                                    error
+                                    data-tooltip="Delete user"
+                                    onClick={() => handleDelete(u.username)}
+                                  >
+                                    <IconTrash />
+                                  </Button>
+                                </>
+                              )}
+                          </td>
+                        )}
                       </tr>
                     ))}
                   </tbody>
@@ -448,6 +521,8 @@ export const UserList = () => {
           </Dimmer>
         </div>
       </PageContent>
+      {banConfirm.children}
+      {deleteConfirm.children}
     </>
   );
 };

--- a/frontend/src/views/users/UserList.tsx
+++ b/frontend/src/views/users/UserList.tsx
@@ -14,7 +14,6 @@ import {
   Scroll,
   SideNav,
   SortIcons,
-  useConfirm,
 } from '@components';
 import { useStore } from '@nanostores/react';
 import {
@@ -23,27 +22,42 @@ import {
   IconArrowLeft,
   IconArrowRight,
   IconBan,
-  IconCirclePlus,
+  IconCaretDown,
+  IconCaretUp,
   IconLock,
   IconRotate,
-  IconTrash,
+  IconShield,
   IconUserPlus,
   IconX,
 } from '@tabler/icons-react';
-import { debounce, duration, logout } from '@utils';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useRoute } from 'wouter';
-import { $omeggaData, $user } from '../../stores/user';
+import { useHasScope } from '@hooks';
+import { duration, logout } from '@utils';
+import { useEffect, useMemo, useState, useRef } from 'react';
+import { Route, Switch, useLocation, useRoute } from 'wouter';
+import { UserInspector } from './UserInspector';
+import { DefaultPermissions } from './DefaultPermissions';
+import { Domains, Permissions } from '../../permissions';
+import { $omeggaData, $user, $usersRefresh } from '../../stores/user';
 import { trpc } from '../../trpc';
+
+const ACTION_CHANGE_PASSWORD = 'Change Password';
+const ACTION_ENABLE_USERS = 'Enable Users';
+const ACTION_ADD_USER = 'Add User';
+const ACTION_DEFAULT_PERMS = 'Default Permissions';
 
 export const UserList = () => {
   const userless = useStore($omeggaData)?.userless;
   const myUser = useStore($user);
 
+  const canList = useHasScope(Permissions.UserList);
+  const canCreate = useHasScope(Permissions.UserCreate);
+  const canEditPerms = useHasScope(Permissions.UserPermissions);
+
   const [pages, setPages] = useState(0);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [users, setUsers] = useState<GetUsersRes['users']>([]);
+  const [search, setSearch] = useState('');
 
   const [error, setError] = useState('');
   const [username, setUsername] = useState('');
@@ -54,34 +68,42 @@ export const UserList = () => {
   const [showCreateUser, setShowCreateUser] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
 
-  // const [userLookup, setUserLookup] = useState<
-  //   Record<string, GetUsersRes['users'][number]>
-  // >({});
-
   const [_location, navigate] = useLocation();
   const [_match, params] = useRoute('/users/:id?');
 
   const utils = trpc.useUtils();
   const createMutation = trpc.user.create.useMutation();
   const passwdMutation = trpc.user.passwd.useMutation();
-  const banMutation = trpc.user.ban.useMutation();
-  const deleteMutation = trpc.user.delete.useMutation();
-  const banConfirm = useConfirm();
-  const deleteConfirm = useConfirm();
+
+  const [showActions, setShowActions] = useState(false);
+
+  const openCredentials = () => {
+    setShowActions(false);
+    setShowCredentials(true);
+    setShowCreateUser(false);
+    if (!userless) setUsername(myUser?.username ?? '');
+    setError('');
+  };
+
+  const openCreateUser = () => {
+    setShowActions(false);
+    setShowCreateUser(true);
+    setShowCredentials(false);
+    setUsername('');
+    setError('');
+  };
+
+  const openDefaultPerms = () => {
+    setShowActions(false);
+    navigate('/users/_defaults');
+  };
 
   const query = useRef({
     page: 0,
-    search: '',
     sort: 'lastSeen',
     direction: -1,
   });
-  const { page, search, sort, direction } = query.current;
-  const [_searchKey, setSearchKey] = useState(0);
-  const setSearch = (search: string) => {
-    query.current.search = search;
-    doSearch();
-    setSearchKey(k => k + 1);
-  };
+  const { page, sort, direction } = query.current;
   const setPage = (page: number | ((old: number) => number)) => {
     if (typeof page === 'function') page = page(query.current.page);
     query.current.page = page;
@@ -94,37 +116,25 @@ export const UserList = () => {
 
   const getUsers = async () => {
     setLoading(true);
-    const { page, search, sort, direction } = query.current;
+    const { page, sort, direction } = query.current;
     const { users, total, pages } = await utils.user.list.fetch({
       page,
-      search,
+      search: '',
       sort,
       direction,
     });
     setPages(pages);
     setTotal(total);
     setUsers(users);
-    // setUserLookup(prev => ({
-    //   ...prev,
-    //   ...Object.fromEntries(users.map(u => [u.username, u])),
-    // }));
     setLoading(false);
   };
   const getUsersRef = useRef<() => Promise<void>>(getUsers);
   getUsersRef.current = getUsers;
 
+  const usersRefresh = useStore($usersRefresh);
   useEffect(() => {
     getUsers();
-  }, []);
-
-  const doSearch = useMemo(
-    () =>
-      debounce(() => {
-        query.current.page = 0;
-        getUsersRef.current?.();
-      }, 500),
-    [],
-  );
+  }, [usersRefresh]);
 
   // update table sort direction
   const setSort = (s: string) => {
@@ -140,26 +150,11 @@ export const UserList = () => {
     getUsers();
   };
 
-  // const selectedUser = useMemo(() => {
-  //   if (!params?.id) return null;
-  //   const user =
-  //     userLookup[params.id] ?? users.find(u => u.username === params.id);
-  //   return user ?? null;
-  // }, [params?.id, userLookup, users]);
-
-  const toggleAddUser = () => {
-    setShowCreateUser(!showCreateUser);
-    setShowCredentials(false);
-    setUsername('');
-    setError('');
-  };
-
-  const toggleCredentials = () => {
-    setShowCredentials(!showCredentials);
-    setShowCreateUser(false);
-    if (!userless) setUsername(myUser?.username ?? '');
-    setError('');
-  };
+  const filteredUsers = useMemo(() => {
+    if (!search) return users;
+    const q = search.toLowerCase();
+    return users.filter(u => (u.username || 'Admin').toLowerCase().includes(q));
+  }, [users, search]);
 
   const hideModals = () => {
     setShowCreateUser(false);
@@ -187,7 +182,13 @@ export const UserList = () => {
       setModalLoading(false);
       if (!err) {
         if (showCredentials && userless) logout();
-        else hideModals();
+        else {
+          const wasCreate = showCreateUser;
+          const createdName = username;
+          hideModals();
+          await getUsers();
+          if (wasCreate) navigate(`/users/${createdName}`);
+        }
         return;
       }
     } catch (e) {
@@ -196,59 +197,127 @@ export const UserList = () => {
     setError(err);
   };
 
-  const handleBan = async (username: string, currentlyBanned: boolean) => {
-    const action = currentlyBanned ? 're-enable' : 'disable';
-    if (!(await banConfirm.prompt(`${action} user "${username}"`))) return;
-    const err = await banMutation.mutateAsync({
-      username,
-      banned: !currentlyBanned,
-    });
-    if (err) setError(err);
-    else getUsers();
-  };
-
-  const handleDelete = async (username: string) => {
-    if (
-      !(await deleteConfirm.prompt(`permanently delete user "${username}"`))
-    )
-      return;
-    const err = await deleteMutation.mutateAsync({ username });
-    if (err) setError(err);
-    else getUsers();
-  };
-
   const ok = useMemo(() => {
     const nameOk = username.length !== 0 || !(showCredentials && !userless);
     return username.match(/^\w{0,32}$/) && nameOk && password.length !== 0;
   }, [username, password, showCredentials, userless]);
 
+  if (!canList) {
+    return (
+      <>
+        <NavHeader title="Account">
+          <div className="widgets-container">
+            <Button normal boxy onClick={() => setShowActions(!showActions)}>
+              {showActions ? <IconCaretUp /> : <IconCaretDown />}
+              Actions
+            </Button>
+            <div
+              className="widgets-list"
+              style={{ display: showActions ? 'block' : 'none' }}
+            >
+              <Button info onClick={openCredentials}>
+                <IconLock />
+                {ACTION_CHANGE_PASSWORD}
+              </Button>
+            </div>
+          </div>
+        </NavHeader>
+        <PageContent>
+          <SideNav />
+          <div className="generic-container players-container">
+            <UserInspector selfUser={myUser?.username} />
+          </div>
+          <Dimmer visible={showCredentials}>
+            <Loader active={modalLoading} size="huge">
+              Submitting
+            </Loader>
+            <Modal visible={!modalLoading}>
+              <Header>Update Credentials</Header>
+              <PopoutContent>
+                <p>Updating credentials for user "{username}"</p>
+                {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+              </PopoutContent>
+              <div className="popout-inputs">
+                <Input
+                  placeholder="password"
+                  type="password"
+                  value={password}
+                  onChange={p => setPassword(p)}
+                />
+                <Input
+                  placeholder="confirm password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={p => setConfirmPassword(p)}
+                />
+              </div>
+              <Footer>
+                <Button
+                  main
+                  disabled={!password.length || confirmPassword !== password}
+                  onClick={() => submit()}
+                >
+                  <IconLock />
+                  Update
+                </Button>
+                <div style={{ flex: 1 }} />
+                <Button normal onClick={hideModals}>
+                  <IconX />
+                  Cancel
+                </Button>
+              </Footer>
+            </Modal>
+          </Dimmer>
+        </PageContent>
+      </>
+    );
+  }
+
   return (
     <>
       <NavHeader title="Users">
-        <span style={{ flex: 1 }} />
-        <Button
-          normal
-          data-tooltip={userless ? 'Enable user sign-in' : 'Change password'}
-          onClick={toggleCredentials}
-        >
-          {userless ? (
-            <>
-              <IconCirclePlus />
-              Enable Users
-            </>
-          ) : (
-            <>
-              <IconLock />
-              Change Password
-            </>
-          )}
-        </Button>
-        {!userless && myUser?.isOwner && (
-          <Button normal onClick={toggleAddUser} data-tooltip="Add a new user">
-            <IconUserPlus />
-            Add User
+        {!userless && canEditPerms && (
+          <Button
+            normal
+            boxy
+            className="default-perms-standalone"
+            onClick={openDefaultPerms}
+          >
+            <IconShield />
+            {ACTION_DEFAULT_PERMS}
           </Button>
         )}
+        <div className="widgets-container">
+          <Button normal boxy onClick={() => setShowActions(!showActions)}>
+            {showActions ? <IconCaretUp /> : <IconCaretDown />}
+            Actions
+          </Button>
+          <div
+            className="widgets-list"
+            style={{ display: showActions ? 'block' : 'none' }}
+          >
+            {!userless && canEditPerms && (
+              <Button
+                normal
+                className="default-perms-dropdown hidden"
+                onClick={openDefaultPerms}
+              >
+                <IconShield />
+                {ACTION_DEFAULT_PERMS}
+              </Button>
+            )}
+            <Button info onClick={openCredentials}>
+              <IconLock />
+              {userless ? ACTION_ENABLE_USERS : ACTION_CHANGE_PASSWORD}
+            </Button>
+            {!userless && canCreate && (
+              <Button main onClick={openCreateUser}>
+                <IconUserPlus />
+                {ACTION_ADD_USER}
+              </Button>
+            )}
+          </div>
+        </div>
       </NavHeader>
       <PageContent>
         <SideNav />
@@ -259,7 +328,7 @@ export const UserList = () => {
                 type="text"
                 placeholder="Search Users..."
                 value={search}
-                onChange={setSearch}
+                onChange={s => setSearch(s)}
               />
               <span style={{ flex: 1 }} />
               <Button
@@ -315,15 +384,10 @@ export const UserList = () => {
                           />
                         </span>
                       </th>
-                      {!userless && myUser?.isOwner && (
-                        <th style={{ width: 1 }}>
-                          <span>Actions</span>
-                        </th>
-                      )}
                     </tr>
                   </thead>
                   <tbody>
-                    {users.map(u => (
+                    {filteredUsers.map(u => (
                       <tr
                         onClick={() => navigate(`/users/${u.username}`)}
                         className={u.username === params?.id ? 'active' : ''}
@@ -355,47 +419,12 @@ export const UserList = () => {
                         >
                           {duration(u.createdAgo)}
                         </td>
-                        {!userless && myUser?.isOwner && (
-                          <td
-                            style={{ whiteSpace: 'nowrap' }}
-                            onClick={e => e.stopPropagation()}
-                          >
-                            {!u.isOwner &&
-                              u.username !== myUser?.username && (
-                                <>
-                                  <Button
-                                    icon
-                                    normal={!u.isBanned}
-                                    warn={!!u.isBanned}
-                                    data-tooltip={
-                                      u.isBanned
-                                        ? 'Re-enable user'
-                                        : 'Disable user'
-                                    }
-                                    onClick={() =>
-                                      handleBan(u.username, !!u.isBanned)
-                                    }
-                                  >
-                                    <IconBan />
-                                  </Button>
-                                  <Button
-                                    icon
-                                    error
-                                    data-tooltip="Delete user"
-                                    onClick={() => handleDelete(u.username)}
-                                  >
-                                    <IconTrash />
-                                  </Button>
-                                </>
-                              )}
-                          </td>
-                        )}
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </Scroll>
-              <Footer className="pagination-footer">
+              <Footer className="pagination-footer" attached>
                 <Button
                   icon
                   normal
@@ -419,7 +448,7 @@ export const UserList = () => {
                     Page {page + 1} of {pages}
                   </div>
                   <div>
-                    Showing {users.length} of {total}
+                    Showing {filteredUsers.length} of {total}
                   </div>
                 </div>
                 <Button
@@ -446,10 +475,16 @@ export const UserList = () => {
               </Loader>
             </div>
           </div>
-          {/* <div className="player-inspector-container">
-            <NavBar>{selectedUserName}</NavBar>
-            <div className="player-inspector"></div>
-          </div> */}
+          <Switch>
+            <Route path="/users/_defaults" component={DefaultPermissions} />
+            <Route path="/users/:id" component={UserInspector} />
+            <Route>
+              <div className="player-inspector-container">
+                <NavBar attached>SELECT A USER</NavBar>
+                <div className="player-inspector" />
+              </div>
+            </Route>
+          </Switch>
           <Dimmer visible={showCredentials || showCreateUser}>
             <Loader active={modalLoading} size="huge">
               Submitting
@@ -469,7 +504,7 @@ export const UserList = () => {
                   </>
                 )}
                 {!userless && showCredentials && (
-                  <p>Updating credentials for user "{username}""</p>
+                  <p>Updating credentials for user "{username}"</p>
                 )}
                 {showCreateUser && (
                   <p>
@@ -521,8 +556,6 @@ export const UserList = () => {
           </Dimmer>
         </div>
       </PageContent>
-      {banConfirm.children}
-      {deleteConfirm.children}
     </>
   );
 };

--- a/frontend/src/views/users/_index.scss
+++ b/frontend/src/views/users/_index.scss
@@ -1,0 +1,1 @@
+@use 'user-inspector';

--- a/frontend/src/views/users/user-inspector.scss
+++ b/frontend/src/views/users/user-inspector.scss
@@ -1,0 +1,204 @@
+@use '../../css/theme';
+@use '../../css/mixins';
+
+.permission-editor {
+  .perm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 10px;
+    min-height: 40px;
+
+    &.root-row {
+      background-color: theme.$br-bg-header;
+    }
+
+    &.domain-row {
+      background-color: theme.$br-bg-header;
+      position: sticky;
+      top: 32px;
+      z-index: 5;
+    }
+
+    &.scope-row {
+      padding-left: 16px;
+
+      &.even {
+        background-color: theme.$br-bg-secondary;
+      }
+      &.odd {
+        background-color: theme.$br-bg-secondary-alt;
+      }
+    }
+  }
+
+  .perm-label {
+    color: theme.$br-element-fg;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &.root-label {
+      color: white;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+
+    &.domain-label {
+      cursor: pointer;
+      color: white;
+      font-weight: bold;
+      user-select: none;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+  }
+
+  .scope-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    margin-right: 8px;
+  }
+
+  .scope-name {
+    color: white;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+  }
+
+  .scope-desc {
+    color: theme.$br-element-fg;
+    font-size: 13px;
+    font-weight: bold;
+  }
+
+  .scope-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+    font-size: 11px;
+    font-weight: bold;
+    border-radius: 3px;
+    flex-shrink: 0;
+
+    &.read {
+      background-color: rgba(theme.$br-info-normal, 0.3);
+      color: theme.$br-info-normal;
+    }
+    &.write {
+      background-color: rgba(theme.$br-warn-normal, 0.3);
+      color: theme.$br-warn-normal;
+    }
+  }
+
+  .inherited {
+    display: inline-flex;
+    align-items: center;
+
+    &.on {
+      color: theme.$br-main-normal;
+    }
+  }
+
+  .scope-controls {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 8px;
+  }
+
+  .level-picker {
+    display: flex;
+    flex-shrink: 0;
+
+    &.dimmed {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    .level-option {
+      border: none;
+      padding: 0 8px;
+      height: 28px;
+      line-height: 28px;
+      font-family: inherit;
+      font-size: 14px;
+      font-weight: bold;
+      text-transform: uppercase;
+      cursor: pointer;
+      border-radius: 0;
+      color: theme.$br-boring-button-fg;
+      @include mixins.br-button(
+        theme.$br-bg-primary,
+        theme.$br-element-hover,
+        theme.$br-element-pressed
+      );
+
+      &.first {
+        border-radius: theme.$br-radius-sm 0 0 theme.$br-radius-sm;
+      }
+
+      &.last {
+        border-radius: 0 theme.$br-radius-sm theme.$br-radius-sm 0;
+      }
+
+      &.active {
+        color: white;
+
+        &.level-all,
+        &.level-everything {
+          @include mixins.br-button(
+            theme.$br-main-normal,
+            theme.$br-main-hover,
+            theme.$br-main-pressed
+          );
+        }
+        &.level-read {
+          @include mixins.br-button(
+            theme.$br-info-normal,
+            theme.$br-info-hover,
+            theme.$br-info-pressed
+          );
+        }
+        &.level-none,
+        &.level-off,
+        &.level-manual {
+          @include mixins.br-button(#2a9d8f, #3dbdad, #1e7268);
+        }
+      }
+    }
+  }
+}
+
+.players-container .players-list {
+  border-bottom-left-radius: theme.$br-radius-md;
+  border-bottom-right-radius: theme.$br-radius-md;
+  overflow: hidden;
+}
+
+.player-inspector-container {
+  .player-inspector.has-footer {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .default-perms-standalone {
+    display: none !important;
+  }
+
+  .default-perms-dropdown.hidden {
+    display: flex !important;
+  }
+}

--- a/frontend/src/views/users/user-inspector.scss
+++ b/frontend/src/views/users/user-inspector.scss
@@ -32,6 +32,15 @@
     }
   }
 
+  .perm-search {
+    padding: 4px 10px;
+    background-color: theme.$br-bg-header;
+
+    .input {
+      width: 100%;
+    }
+  }
+
   .perm-label {
     color: theme.$br-element-fg;
     flex: 1;
@@ -204,10 +213,10 @@
 }
 
 .widgets-list-up {
-  bottom: 100%;
+  bottom: 100% !important;
   top: auto !important;
   right: 0;
-  width: max-content;
+  min-width: max-content !important;
 }
 
 .mfa-manager {

--- a/frontend/src/views/users/user-inspector.scss
+++ b/frontend/src/views/users/user-inspector.scss
@@ -180,6 +180,16 @@
   }
 }
 
+.perm-error {
+  background-color: rgba(theme.$br-error-normal, 0.2);
+  color: theme.$br-error-normal;
+  padding: 8px 12px;
+  margin: 8px;
+  border-radius: theme.$br-radius-sm;
+  font-weight: bold;
+  text-transform: capitalize;
+}
+
 .players-container .players-list {
   border-bottom-left-radius: theme.$br-radius-md;
   border-bottom-right-radius: theme.$br-radius-md;
@@ -193,7 +203,128 @@
   }
 }
 
-@media screen and (max-width: 1024px) {
+.widgets-list-up {
+  bottom: 100%;
+  top: auto !important;
+  right: 0;
+  width: max-content;
+}
+
+.mfa-manager {
+  .mfa-error {
+    background-color: rgba(theme.$br-error-normal, 0.2);
+    color: theme.$br-error-normal;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    border-radius: theme.$br-radius-sm;
+    font-weight: bold;
+    text-transform: capitalize;
+  }
+
+  .note {
+    color: theme.$br-element-fg !important;
+    font-size: 12px;
+  }
+
+  .mfa-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 0;
+
+    .input {
+      min-width: 180px;
+      flex: 1;
+    }
+
+    .button {
+      margin-right: 0;
+    }
+  }
+
+  .totp-setup {
+    .qr-code {
+      display: block;
+      width: 200px;
+      height: 200px;
+      margin: 8px 0;
+      border-radius: theme.$br-radius-sm;
+    }
+
+    .manual-secret {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      code {
+        font-family: monospace;
+        color: white;
+        user-select: all;
+        word-break: break-all;
+      }
+
+      .button {
+        flex-shrink: 0;
+      }
+    }
+  }
+
+  .passkey-list {
+    .passkey-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+
+      .passkey-name {
+        color: white;
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        flex: 1;
+      }
+
+      .passkey-meta {
+        color: theme.$br-element-fg;
+        font-size: 13px;
+      }
+    }
+  }
+
+  .recovery-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 120px);
+    gap: 4px;
+    padding: 8px 0;
+
+    code {
+      font-family: monospace;
+      color: white;
+      font-size: 16px;
+      font-weight: bold;
+      padding: 4px 8px;
+      background-color: theme.$br-bg-primary;
+      border-radius: theme.$br-radius-sm;
+      text-align: center;
+      user-select: all;
+    }
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .mfa-manager .mfa-actions {
+    flex-direction: column;
+    align-items: stretch;
+
+    .input {
+      max-width: none;
+    }
+  }
+}
+
+@media screen and (max-width: 1200px) {
   .default-perms-standalone {
     display: none !important;
   }

--- a/frontend/src/views/worlds/WorldInspector.tsx
+++ b/frontend/src/views/worlds/WorldInspector.tsx
@@ -28,6 +28,7 @@ export const WorldInspector = () => {
   const activeWorld = useStore($activeWorld);
   const liveness = useStore($liveness);
 
+  const canRevisions = useHasScope(Permissions.WorldRevisions);
   const canUse = useHasScope(Permissions.WorldUse);
   const canLoad = useHasScope(Permissions.WorldLoad);
 
@@ -46,7 +47,7 @@ export const WorldInspector = () => {
   // Load the revisions if the world is selected and the server is started
   // TODO: load revisions by parsing the brdb file
   useEffect(() => {
-    if (!selectedWorld || !liveness.started) return;
+    if (!selectedWorld || !liveness.started || !canRevisions) return;
     setLoading(true);
     setRevisions(null);
     Promise.all([
@@ -155,7 +156,11 @@ export const WorldInspector = () => {
               )}
               {revisions === null && !loading && liveness.started && (
                 <div className="revision-item">
-                  <i className="revision-note">World might not exist</i>
+                  <i className="revision-note">
+                    {canRevisions
+                      ? 'World might not exist'
+                      : 'Missing permission to view revisions'}
+                  </i>
                 </div>
               )}
               {revisions?.map(r => (

--- a/frontend/src/views/worlds/WorldInspector.tsx
+++ b/frontend/src/views/worlds/WorldInspector.tsx
@@ -8,12 +8,14 @@ import {
   SortIcons,
   useConfirm,
 } from '@components';
+import { useHasScope } from '@hooks';
 import { useStore } from '@nanostores/react';
 import { IconPlayerPlay, IconStar, IconStarOff } from '@tabler/icons-react';
 import range from 'lodash/range';
 import sortBy from 'lodash/sortBy';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useRoute } from 'wouter';
+import { Permissions } from '../../permissions';
 import { $liveness } from '../../stores/liveness';
 import { $activeWorld, $nextWorld } from '../../stores/worlds';
 import { trpc } from '../../trpc';
@@ -25,6 +27,9 @@ export const WorldInspector = () => {
   const nextWorld = useStore($nextWorld);
   const activeWorld = useStore($activeWorld);
   const liveness = useStore($liveness);
+
+  const canUse = useHasScope(Permissions.WorldUse);
+  const canLoad = useHasScope(Permissions.WorldLoad);
 
   const [loading, setLoading] = useState(false);
   const [revisions, setRevisions] = useState<WorldRevisionsRes | null>(null);
@@ -162,27 +167,30 @@ export const WorldInspector = () => {
                       {new Date(r.date).toLocaleString()}
                     </div>
                   </div>
-                  <Button
-                    icon
-                    main
-                    disabled={waiting || !liveness.started}
-                    onClick={() =>
-                      confirm
-                        .prompt(
-                          <p>
-                            Are you sure you want to load revision {r.index} of{' '}
-                            <b style={{ color: 'white' }}>{selectedWorld}</b>?
-                            Unsaved work will be lost.
-                          </p>,
-                        )
-                        .then(ok => {
-                          ok && loadWorld(r.index);
-                        })
-                    }
-                    data-tooltip={`Load revision ${r.index}`}
-                  >
-                    <IconPlayerPlay />
-                  </Button>
+                  {canLoad && (
+                    <Button
+                      icon
+                      main
+                      disabled={waiting || !liveness.started}
+                      onClick={() =>
+                        confirm
+                          .prompt(
+                            <p>
+                              Are you sure you want to load revision {r.index}{' '}
+                              of{' '}
+                              <b style={{ color: 'white' }}>{selectedWorld}</b>?
+                              Unsaved work will be lost.
+                            </p>,
+                          )
+                          .then(ok => {
+                            ok && loadWorld(r.index);
+                          })
+                      }
+                      data-tooltip={`Load revision ${r.index}`}
+                    >
+                      <IconPlayerPlay />
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>
@@ -190,7 +198,7 @@ export const WorldInspector = () => {
         )}
       </div>
       <Footer attached>
-        {activeWorld !== selectedWorld && (
+        {canUse && activeWorld !== selectedWorld && (
           <Button
             normal
             disabled={waiting || !selectedWorld}
@@ -201,7 +209,7 @@ export const WorldInspector = () => {
             Make Default
           </Button>
         )}
-        {activeWorld === selectedWorld && (
+        {canUse && activeWorld === selectedWorld && (
           <Button
             warn
             disabled={waiting || !selectedWorld}
@@ -214,27 +222,29 @@ export const WorldInspector = () => {
         )}
         <span style={{ flex: 1 }} />
 
-        <Button
-          main
-          data-tooltip="Load this world immediately"
-          disabled={waiting || !liveness.started || !selectedWorld}
-          onClick={() =>
-            confirm
-              .prompt(
-                <p>
-                  Are you sure you want to load{' '}
-                  <b style={{ color: 'white' }}>{selectedWorld}</b>? Unsaved
-                  work will be lost.
-                </p>,
-              )
-              .then(ok => {
-                ok && loadWorld();
-              })
-          }
-        >
-          <IconPlayerPlay />
-          Load
-        </Button>
+        {canLoad && (
+          <Button
+            main
+            data-tooltip="Load this world immediately"
+            disabled={waiting || !liveness.started || !selectedWorld}
+            onClick={() =>
+              confirm
+                .prompt(
+                  <p>
+                    Are you sure you want to load{' '}
+                    <b style={{ color: 'white' }}>{selectedWorld}</b>? Unsaved
+                    work will be lost.
+                  </p>,
+                )
+                .then(ok => {
+                  ok && loadWorld();
+                })
+            }
+          >
+            <IconPlayerPlay />
+            Load
+          </Button>
+        )}
       </Footer>
       {confirm.children}
     </div>

--- a/frontend/src/views/worlds/WorldList.tsx
+++ b/frontend/src/views/worlds/WorldList.tsx
@@ -10,6 +10,7 @@ import {
   SideNav,
   useConfirm,
 } from '@components';
+import { useHasScope, useRequireDomain } from '@hooks';
 import { useStore } from '@nanostores/react';
 import {
   IconCaretDown,
@@ -27,6 +28,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { Link, useRoute } from 'wouter';
+import { Domains, Permissions } from '../../permissions';
 import { useServerLiveness } from '../../stores/liveness';
 import { $activeWorld, $nextWorld } from '../../stores/worlds';
 import { trpc } from '../../trpc';
@@ -35,6 +37,7 @@ import { WorldInspector } from './WorldInspector';
 const MAP_OPTIONS = ['Plate', 'Space', 'Studio', 'Peaks'];
 
 export const WorldList = () => {
+  const canAccess = useRequireDomain(Domains.World);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [worlds, setWorlds] = useState<string[]>([]);
@@ -42,6 +45,10 @@ export const WorldList = () => {
   const nextWorld = useStore($nextWorld);
   const activeWorld = useStore($activeWorld);
   const [showWidgets, setShowWidgets] = useState(false);
+
+  const canSave = useHasScope(Permissions.WorldSave);
+  const canCreate = useHasScope(Permissions.WorldCreate);
+  const canUse = useHasScope(Permissions.WorldUse);
 
   const liveness = useServerLiveness();
 
@@ -171,10 +178,12 @@ export const WorldList = () => {
     ),
   });
 
+  if (!canAccess) return null;
+
   return (
     <>
       <NavHeader title="Worlds">
-        <div className="widgets-container worlds">
+        {(canSave || canCreate || canUse) && <div className="widgets-container worlds">
           <Button
             normal
             boxy
@@ -188,66 +197,74 @@ export const WorldList = () => {
             className="widgets-list"
             style={{ display: showWidgets ? 'block' : 'none' }}
           >
-            <Button
-              info
-              disabled={waiting || !liveness.started}
-              data-tooltip="Save the currently loaded world"
-              onClick={() => {
-                setShowWidgets(false);
-                saveWorld();
-              }}
-            >
-              <IconDeviceFloppy />
-              Save World
-            </Button>
-            <Button
-              normal
-              disabled={waiting || !liveness.started}
-              data-tooltip="Save a copy of the currently loaded world"
-              onClick={() => {
-                setShowWidgets(false);
-                setWorldName(null);
-                saveAsConfirm.prompt().then(name => {
-                  name && saveWorldAs(name);
-                });
-              }}
-            >
-              <IconClipboardPlus />
-              Save As
-            </Button>
-            <Button
-              main
-              disabled={waiting || !liveness.started}
-              data-tooltip="Create a new world"
-              onClick={() => {
-                setShowWidgets(false);
-                setWorldName(null);
-                setNewMap('Plate');
-                newMapConfirm.prompt().then(data => {
-                  if (data) {
-                    createWorld(data.name, data.map);
-                  }
-                });
-              }}
-            >
-              <IconWorldPlus />
-              New World
-            </Button>
-            <Button
-              normal={activeWorld === null}
-              warn={activeWorld !== null}
-              disabled={waiting || !activeWorld}
-              data-tooltip="Remove the default world for the server (on startup)"
-              onClick={() => {
-                setShowWidgets(false);
-                clearActiveWorld();
-              }}
-            >
-              <IconStarOff />
-              Clear Default
-            </Button>
+            {canSave && (
+              <Button
+                info
+                disabled={waiting || !liveness.started}
+                data-tooltip="Save the currently loaded world"
+                onClick={() => {
+                  setShowWidgets(false);
+                  saveWorld();
+                }}
+              >
+                <IconDeviceFloppy />
+                Save World
+              </Button>
+            )}
+            {canSave && (
+              <Button
+                normal
+                disabled={waiting || !liveness.started}
+                data-tooltip="Save a copy of the currently loaded world"
+                onClick={() => {
+                  setShowWidgets(false);
+                  setWorldName(null);
+                  saveAsConfirm.prompt().then(name => {
+                    name && saveWorldAs(name);
+                  });
+                }}
+              >
+                <IconClipboardPlus />
+                Save As
+              </Button>
+            )}
+            {canCreate && (
+              <Button
+                main
+                disabled={waiting || !liveness.started}
+                data-tooltip="Create a new world"
+                onClick={() => {
+                  setShowWidgets(false);
+                  setWorldName(null);
+                  setNewMap('Plate');
+                  newMapConfirm.prompt().then(data => {
+                    if (data) {
+                      createWorld(data.name, data.map);
+                    }
+                  });
+                }}
+              >
+                <IconWorldPlus />
+                New World
+              </Button>
+            )}
+            {canUse && (
+              <Button
+                normal={activeWorld === null}
+                warn={activeWorld !== null}
+                disabled={waiting || !activeWorld}
+                data-tooltip="Remove the default world for the server (on startup)"
+                onClick={() => {
+                  setShowWidgets(false);
+                  clearActiveWorld();
+                }}
+              >
+                <IconStarOff />
+                Clear Default
+              </Button>
+            )}
           </div>
-        </div>
+        </div>}
       </NavHeader>
       <PageContent>
         <SideNav />

--- a/frontend/src/views/worlds/WorldList.tsx
+++ b/frontend/src/views/worlds/WorldList.tsx
@@ -10,7 +10,7 @@ import {
   SideNav,
   useConfirm,
 } from '@components';
-import { useHasScope, useRequireDomain } from '@hooks';
+import { useHasScope, useRequireScope } from '@hooks';
 import { useStore } from '@nanostores/react';
 import {
   IconCaretDown,
@@ -28,7 +28,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { Link, useRoute } from 'wouter';
-import { Domains, Permissions } from '../../permissions';
+import { Permissions } from '../../permissions';
 import { useServerLiveness } from '../../stores/liveness';
 import { $activeWorld, $nextWorld } from '../../stores/worlds';
 import { trpc } from '../../trpc';
@@ -37,7 +37,7 @@ import { WorldInspector } from './WorldInspector';
 const MAP_OPTIONS = ['Plate', 'Space', 'Studio', 'Peaks'];
 
 export const WorldList = () => {
-  const canAccess = useRequireDomain(Domains.World);
+  const canAccess = useRequireScope(Permissions.WorldList);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [worlds, setWorlds] = useState<string[]>([]);
@@ -46,9 +46,12 @@ export const WorldList = () => {
   const activeWorld = useStore($activeWorld);
   const [showWidgets, setShowWidgets] = useState(false);
 
+  const canRevisions = useHasScope(Permissions.WorldRevisions);
   const canSave = useHasScope(Permissions.WorldSave);
   const canCreate = useHasScope(Permissions.WorldCreate);
   const canUse = useHasScope(Permissions.WorldUse);
+  const canActive = useHasScope(Permissions.WorldActive);
+  const canNext = useHasScope(Permissions.WorldNext);
 
   const liveness = useServerLiveness();
 
@@ -64,8 +67,8 @@ export const WorldList = () => {
     setLoading(true);
     const [worlds, active, next] = await Promise.all([
       utils.world.list.fetch(),
-      utils.world.active.fetch(),
-      utils.world.next.fetch(),
+      canActive ? utils.world.active.fetch() : null,
+      canNext ? utils.world.next.fetch() : null,
     ]);
     setWorlds(worlds);
     $activeWorld.set(active);
@@ -81,8 +84,10 @@ export const WorldList = () => {
     const ok = await useMut.mutateAsync({});
     if (ok) {
       $activeWorld.set(null);
-      const next = await utils.world.next.fetch();
-      $nextWorld.set(next);
+      if (canNext) {
+        const next = await utils.world.next.fetch();
+        $nextWorld.set(next);
+      }
     }
     setWaiting(false);
   };
@@ -183,88 +188,90 @@ export const WorldList = () => {
   return (
     <>
       <NavHeader title="Worlds">
-        {(canSave || canCreate || canUse) && <div className="widgets-container worlds">
-          <Button
-            normal
-            boxy
-            data-tooltip="Show more world actions"
-            onClick={() => setShowWidgets(!showWidgets)}
-          >
-            {showWidgets ? <IconCaretUp /> : <IconCaretDown />}
-            Actions
-          </Button>
-          <div
-            className="widgets-list"
-            style={{ display: showWidgets ? 'block' : 'none' }}
-          >
-            {canSave && (
-              <Button
-                info
-                disabled={waiting || !liveness.started}
-                data-tooltip="Save the currently loaded world"
-                onClick={() => {
-                  setShowWidgets(false);
-                  saveWorld();
-                }}
-              >
-                <IconDeviceFloppy />
-                Save World
-              </Button>
-            )}
-            {canSave && (
-              <Button
-                normal
-                disabled={waiting || !liveness.started}
-                data-tooltip="Save a copy of the currently loaded world"
-                onClick={() => {
-                  setShowWidgets(false);
-                  setWorldName(null);
-                  saveAsConfirm.prompt().then(name => {
-                    name && saveWorldAs(name);
-                  });
-                }}
-              >
-                <IconClipboardPlus />
-                Save As
-              </Button>
-            )}
-            {canCreate && (
-              <Button
-                main
-                disabled={waiting || !liveness.started}
-                data-tooltip="Create a new world"
-                onClick={() => {
-                  setShowWidgets(false);
-                  setWorldName(null);
-                  setNewMap('Plate');
-                  newMapConfirm.prompt().then(data => {
-                    if (data) {
-                      createWorld(data.name, data.map);
-                    }
-                  });
-                }}
-              >
-                <IconWorldPlus />
-                New World
-              </Button>
-            )}
-            {canUse && (
-              <Button
-                normal={activeWorld === null}
-                warn={activeWorld !== null}
-                disabled={waiting || !activeWorld}
-                data-tooltip="Remove the default world for the server (on startup)"
-                onClick={() => {
-                  setShowWidgets(false);
-                  clearActiveWorld();
-                }}
-              >
-                <IconStarOff />
-                Clear Default
-              </Button>
-            )}
+        {(canSave || canCreate || canUse) && (
+          <div className="widgets-container worlds">
+            <Button
+              normal
+              boxy
+              data-tooltip="Show more world actions"
+              onClick={() => setShowWidgets(!showWidgets)}
+            >
+              {showWidgets ? <IconCaretUp /> : <IconCaretDown />}
+              Actions
+            </Button>
+            <div
+              className="widgets-list"
+              style={{ display: showWidgets ? 'block' : 'none' }}
+            >
+              {canSave && (
+                <Button
+                  info
+                  disabled={waiting || !liveness.started}
+                  data-tooltip="Save the currently loaded world"
+                  onClick={() => {
+                    setShowWidgets(false);
+                    saveWorld();
+                  }}
+                >
+                  <IconDeviceFloppy />
+                  Save World
+                </Button>
+              )}
+              {canSave && (
+                <Button
+                  normal
+                  disabled={waiting || !liveness.started}
+                  data-tooltip="Save a copy of the currently loaded world"
+                  onClick={() => {
+                    setShowWidgets(false);
+                    setWorldName(null);
+                    saveAsConfirm.prompt().then(name => {
+                      name && saveWorldAs(name);
+                    });
+                  }}
+                >
+                  <IconClipboardPlus />
+                  Save As
+                </Button>
+              )}
+              {canCreate && (
+                <Button
+                  main
+                  disabled={waiting || !liveness.started}
+                  data-tooltip="Create a new world"
+                  onClick={() => {
+                    setShowWidgets(false);
+                    setWorldName(null);
+                    setNewMap('Plate');
+                    newMapConfirm.prompt().then(data => {
+                      if (data) {
+                        createWorld(data.name, data.map);
+                      }
+                    });
+                  }}
+                >
+                  <IconWorldPlus />
+                  New World
+                </Button>
+              )}
+              {canUse && (
+                <Button
+                  normal={activeWorld === null}
+                  warn={activeWorld !== null}
+                  disabled={waiting || !activeWorld}
+                  data-tooltip="Remove the default world for the server (on startup)"
+                  onClick={() => {
+                    setShowWidgets(false);
+                    clearActiveWorld();
+                  }}
+                >
+                  <IconStarOff />
+                  Clear Default
+                </Button>
+              )}
+            </div>
           </div>
-        </div>}
+        )}
       </NavHeader>
       <PageContent>
         <SideNav />

--- a/frontend/src/views/worlds/world-inspector.scss
+++ b/frontend/src/views/worlds/world-inspector.scss
@@ -48,8 +48,9 @@
   color: theme.$br-boring-button-fg;
 
   .revision-note {
-    color: theme.$br-button-fg;
+    color: theme.$br-element-fg;
     flex: 1;
+    padding: 8px;
   }
 
   .revision-index {

--- a/frontend/src/views/worlds/world-list.scss
+++ b/frontend/src/views/worlds/world-list.scss
@@ -118,7 +118,7 @@
   border-bottom-right-radius: theme.$br-radius-md;
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1200px) {
   .worlds-container {
     flex-direction: column;
   }

--- a/frontend/src/views/worlds/world-list.scss
+++ b/frontend/src/views/worlds/world-list.scss
@@ -5,7 +5,10 @@
   .button {
     border-radius: 0;
     margin-right: 0;
-    text-align: left;
+    justify-content: flex-start;
+    white-space: nowrap;
+    width: 100%;
+    box-sizing: border-box;
   }
   .button:first-child {
     border-top-left-radius: theme.$br-radius-md;
@@ -113,4 +116,15 @@
   position: relative;
   border-bottom-left-radius: theme.$br-radius-md;
   border-bottom-right-radius: theme.$br-radius-md;
+}
+
+@media screen and (max-width: 1024px) {
+  .worlds-container {
+    flex-direction: column;
+  }
+
+  .worlds-list-container {
+    margin-right: 0;
+    margin-bottom: 16px;
+  }
 }

--- a/frontend/src/widgets/chat/index.tsx
+++ b/frontend/src/widgets/chat/index.tsx
@@ -27,7 +27,10 @@ export const ChatWidget = () => {
     }
   };
 
-  const { data: recentChats } = trpc.chat.recent.useQuery();
+  const canRecent = useHasScope(Permissions.ChatRecent);
+  const { data: recentChats } = trpc.chat.recent.useQuery(undefined, {
+    enabled: canRecent,
+  });
 
   useEffect(() => {
     if (recentChats) {
@@ -36,6 +39,7 @@ export const ChatWidget = () => {
   }, [recentChats]);
 
   trpc.chat.onMessage.useSubscription(undefined, {
+    enabled: canRecent,
     onData: (log: ChatEntry) => {
       setChats(prevChats => {
         const updatedChats = [...prevChats, log];

--- a/frontend/src/widgets/chat/index.tsx
+++ b/frontend/src/widgets/chat/index.tsx
@@ -5,7 +5,7 @@ import { IconSend } from '@tabler/icons-react';
 import Linkify from 'linkify-react';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Permissions } from '../../permissions';
-import { trpc } from '../../trpc';
+import { handleGlobalError, trpc } from '../../trpc';
 
 type ChatEntry = IStoreChat & {
   _id: string;
@@ -40,6 +40,7 @@ export const ChatWidget = () => {
 
   trpc.chat.onMessage.useSubscription(undefined, {
     enabled: canRecent,
+    onError: handleGlobalError,
     onData: (log: ChatEntry) => {
       setChats(prevChats => {
         const updatedChats = [...prevChats, log];

--- a/frontend/src/widgets/chat/index.tsx
+++ b/frontend/src/widgets/chat/index.tsx
@@ -1,8 +1,10 @@
 import { Button, Footer, Input, Scroll, UserName } from '@components';
 import type { IStoreChat } from '@backend/types';
+import { useHasScope } from '@hooks';
 import { IconSend } from '@tabler/icons-react';
 import Linkify from 'linkify-react';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 
 type ChatEntry = IStoreChat & {
@@ -12,6 +14,7 @@ type ChatEntry = IStoreChat & {
 };
 
 export const ChatWidget = () => {
+  const canSend = useHasScope(Permissions.ChatSend);
   const [chats, setChats] = useState<ChatEntry[]>([]);
   const [message, setMessage] = useState('');
   const ref = useRef<HTMLDivElement | null>(null);
@@ -90,25 +93,27 @@ export const ChatWidget = () => {
           ))}
         </div>
       </Scroll>
-      <form onSubmit={sendMessage}>
-        <Footer>
-          <Input
-            roboto
-            type="text"
-            placeholder="Message"
-            value={message}
-            onChange={v => setMessage(v)}
-          />
-          <Button
-            normal
-            icon
-            style={{ marginLeft: '10px' }}
-            onClick={sendMessage}
-          >
-            <IconSend />
-          </Button>
-        </Footer>
-      </form>
+      {canSend && (
+        <form onSubmit={sendMessage}>
+          <Footer>
+            <Input
+              roboto
+              type="text"
+              placeholder="Message"
+              value={message}
+              onChange={v => setMessage(v)}
+            />
+            <Button
+              normal
+              icon
+              style={{ marginLeft: '10px' }}
+              onClick={sendMessage}
+            >
+              <IconSend />
+            </Button>
+          </Footer>
+        </form>
+      )}
     </div>
   );
 };

--- a/frontend/src/widgets/status/index.tsx
+++ b/frontend/src/widgets/status/index.tsx
@@ -5,10 +5,11 @@ import { duration } from '@utils';
 import { useEffect, useState } from 'react';
 import { Link } from 'wouter';
 import { Permissions } from '../../permissions';
-import { trpc } from '../../trpc';
+import { handleGlobalError, trpc } from '../../trpc';
 
 export const StatusWidget = () => {
   const canStatus = useHasScope(Permissions.ServerStatus);
+  const canPlayerList = useHasScope(Permissions.PlayerList);
   const [status, setStatus] = useState<IServerStatus | null>(null);
 
   const { data: queryStatus } = trpc.server.status.useQuery(undefined, {
@@ -23,6 +24,7 @@ export const StatusWidget = () => {
 
   trpc.server.onHeartbeat.useSubscription(undefined, {
     enabled: canStatus,
+    onError: handleGlobalError,
     onData: setStatus,
   });
 
@@ -57,9 +59,13 @@ export const StatusWidget = () => {
                 {status.players.map(player => (
                   <tr key={player.address + player.id}>
                     <td>
-                      <Link className="user" to={'/players/' + player.id}>
-                        {player.name}
-                      </Link>
+                      {canPlayerList ? (
+                        <Link className="user" to={'/players/' + player.id}>
+                          {player.name}
+                        </Link>
+                      ) : (
+                        <span className="user">{player.name}</span>
+                      )}
                     </td>
                     <td style={{ textAlign: 'right' }}>
                       {duration(player.time)}

--- a/frontend/src/widgets/status/index.tsx
+++ b/frontend/src/widgets/status/index.tsx
@@ -1,16 +1,20 @@
 import { Loader, Scroll } from '@components';
+import { useHasScope } from '@hooks';
 import type { IServerStatus } from '@omegga/types';
 import { duration } from '@utils';
 import { useEffect, useState } from 'react';
 import { Link } from 'wouter';
+import { Permissions } from '../../permissions';
 import { trpc } from '../../trpc';
 
 export const StatusWidget = () => {
+  const canStatus = useHasScope(Permissions.ServerStatus);
   const [status, setStatus] = useState<IServerStatus | null>(null);
 
-  const { data: queryStatus } = trpc.server.status.useQuery();
+  const { data: queryStatus } = trpc.server.status.useQuery(undefined, {
+    enabled: canStatus,
+  });
 
-  // Sync query data into state so subscription updates merge seamlessly
   useEffect(() => {
     if (queryStatus && !status) {
       setStatus(queryStatus);
@@ -18,6 +22,7 @@ export const StatusWidget = () => {
   }, [queryStatus]);
 
   trpc.server.onHeartbeat.useSubscription(undefined, {
+    enabled: canStatus,
     onData: setStatus,
   });
 

--- a/frontend/src/widgets/utilization/index.tsx
+++ b/frontend/src/widgets/utilization/index.tsx
@@ -1,6 +1,8 @@
 import { Loader } from '@components';
+import { useHasScope } from '@hooks';
 import { IconArrowDown, IconArrowUp, IconCpu } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Permissions } from '../../permissions';
 import type { RouterOutputs } from '../../trpc';
 import { trpc } from '../../trpc';
 
@@ -135,7 +137,10 @@ export const UtilizationWidget = () => {
     tick(n => n + 1);
   }, []);
 
-  const { data: queryUtil } = trpc.server.utilization.useQuery();
+  const canUtil = useHasScope(Permissions.ServerUtilization);
+  const { data: queryUtil } = trpc.server.utilization.useQuery(undefined, {
+    enabled: canUtil,
+  });
 
   useEffect(() => {
     if (!queryUtil) return;
@@ -155,6 +160,7 @@ export const UtilizationWidget = () => {
   }, [queryUtil]);
 
   trpc.server.onUtilization.useSubscription(undefined, {
+    enabled: canUtil,
     onData: handleData,
   });
 

--- a/frontend/src/widgets/utilization/index.tsx
+++ b/frontend/src/widgets/utilization/index.tsx
@@ -3,8 +3,7 @@ import { useHasScope } from '@hooks';
 import { IconArrowDown, IconArrowUp, IconCpu } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Permissions } from '../../permissions';
-import type { RouterOutputs } from '../../trpc';
-import { trpc } from '../../trpc';
+import { handleGlobalError, trpc, type RouterOutputs } from '../../trpc';
 
 type Utilization =
   RouterOutputs['server']['onUtilization'] extends AsyncIterable<infer T>
@@ -161,6 +160,7 @@ export const UtilizationWidget = () => {
 
   trpc.server.onUtilization.useSubscription(undefined, {
     enabled: canUtil,
+    onError: handleGlobalError,
     onData: handleData,
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omegga",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omegga",
-      "version": "1.5.4",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "@swc/core": "^1.2.173",
@@ -3433,9 +3433,9 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3446,7 +3446,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -5291,14 +5291,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -5317,7 +5317,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -8077,9 +8077,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -13736,9 +13736,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "requires": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -13748,7 +13748,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -14998,13 +14998,13 @@
       "dev": true
     },
     "express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -15023,7 +15023,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -16901,9 +16901,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "requires": {
         "side-channel": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
+        "@simplewebauthn/browser": "^13.3.0",
+        "@simplewebauthn/server": "^13.3.0",
         "@swc/core": "^1.2.173",
         "@tanstack/react-query": "^5.90.21",
         "@trpc/client": "^11.12.0",
@@ -35,9 +37,11 @@
         "lodash": "^4.17.21",
         "nedb-promises": "^5.0.1",
         "nedb-promises-session-store": "1.0.0",
+        "otpauth": "^9.5.1",
         "pako": "^2.1.0",
         "pem": "^1.14.8",
         "prompts": "^2.4.2",
+        "qrcode": "^1.5.4",
         "readline": "^1.3.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.4",
@@ -70,6 +74,7 @@
         "@types/node": "^24.0.13",
         "@types/pem": "^1.9.6",
         "@types/prompts": "^2.0.14",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/react-grid-layout": "^1.3.5",
@@ -749,6 +754,12 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -885,6 +896,12 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@nanostores/react": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-1.0.0.tgz",
@@ -903,6 +920,18 @@
       "peerDependencies": {
         "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^1.0.0",
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1251,6 +1280,174 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1681,6 +1878,31 @@
       "license": "MIT",
       "dependencies": {
         "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/core": {
@@ -2205,6 +2427,16 @@
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
       "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3301,6 +3533,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4267,6 +4513,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -4377,6 +4632,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/disrequire": {
@@ -5588,7 +5849,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -5728,7 +5988,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7064,7 +7323,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -7706,6 +7964,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/otpauth": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.1.tgz",
+      "integrity": "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -7744,7 +8014,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -7756,7 +8025,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -7771,7 +8039,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7807,7 +8074,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7900,6 +8166,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8072,6 +8347,116 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -8376,6 +8761,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8455,7 +8846,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8469,6 +8859,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/requizzle": {
       "version": "0.2.4",
@@ -8918,6 +9314,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9845,6 +10247,30 @@
         "ts-patch": "bin/ts-patch.js",
         "tspc": "bin/tspc.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -11528,6 +11954,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -12053,6 +12485,11 @@
         "levn": "^0.4.1"
       }
     },
+    "@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="
+    },
     "@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -12148,12 +12585,22 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
+    "@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="
+    },
     "@nanostores/react": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-1.0.0.tgz",
       "integrity": "sha512-eDduyNy+lbQJMg6XxZ/YssQqF6b4OXMFEZMYKPJCCmBevp1lg0g+4ZRi94qGHirMtsNfAWKNwsjOhC+q1gvC+A==",
       "dev": true,
       "requires": {}
+    },
+    "@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -12297,6 +12744,158 @@
       "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "dev": true,
       "optional": true
+    },
+    "@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "requires": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "requires": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      }
     },
     "@pkgr/core": {
       "version": "0.2.7",
@@ -12535,6 +13134,26 @@
       "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
       "requires": {
         "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
+    "@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="
+    },
+    "@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "requires": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
       }
     },
     "@swc/core": {
@@ -12879,6 +13498,15 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
       "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -13651,6 +14279,16 @@
         "is-array-buffer": "^3.0.4"
       }
     },
+    "asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "requires": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      }
+    },
     "assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -14311,6 +14949,11 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -14379,6 +15022,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "disrequire": {
       "version": "1.1.2",
@@ -15242,7 +15890,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -15333,8 +15980,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.3.0",
@@ -16216,7 +16862,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
@@ -16651,6 +17296,14 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "otpauth": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.1.tgz",
+      "integrity": "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==",
+      "requires": {
+        "@noble/hashes": "2.2.0"
+      }
+    },
     "own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -16675,7 +17328,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       },
@@ -16684,7 +17336,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -16694,8 +17345,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "2.1.0",
@@ -16719,8 +17369,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -16785,6 +17434,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
@@ -16899,6 +17553,88 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "requires": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
+    },
+    "qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "requires": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "qs": {
       "version": "6.15.2",
@@ -17107,6 +17843,11 @@
         }
       }
     },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
     "reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -17160,13 +17901,17 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requizzle": {
       "version": "0.2.4",
@@ -17470,6 +18215,11 @@
         "parseurl": "~1.3.3",
         "send": "0.19.0"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -18088,6 +18838,26 @@
         "resolve": "^1.22.2",
         "semver": "^7.6.3",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "tunnel-agent": {
@@ -19022,6 +19792,11 @@
         "is-weakmap": "^2.0.2",
         "is-weakset": "^2.0.3"
       }
+    },
+    "which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "which-typed-array": {
       "version": "1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omegga",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Brickadia server installer, updater, manager, wrapper, configurator, and automator",
   "engines": {
     "node": ">=23.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "omegga": "./bin/omegga"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
+    "@simplewebauthn/server": "^13.3.0",
     "@swc/core": "^1.2.173",
     "@tanstack/react-query": "^5.90.21",
     "@trpc/client": "^11.12.0",
@@ -36,9 +38,11 @@
     "lodash": "^4.17.21",
     "nedb-promises": "^5.0.1",
     "nedb-promises-session-store": "1.0.0",
+    "otpauth": "^9.5.1",
     "pako": "^2.1.0",
     "pem": "^1.14.8",
     "prompts": "^2.4.2",
+    "qrcode": "^1.5.4",
     "readline": "^1.3.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.4",
@@ -69,6 +73,7 @@
     "@types/node": "^24.0.13",
     "@types/pem": "^1.9.6",
     "@types/prompts": "^2.0.14",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/react-grid-layout": "^1.3.5",

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -820,6 +820,52 @@ Players: ${status.players.length === 0 ? 'none'.grey : ''}
       }
     },
   },
+  {
+    aliases: ['user'],
+    desc: 'manage web UI users',
+    descLines: () => [
+      "/user passwd <username>   - Reset a user's password",
+      '/user resetmfa <username> - Clear TOTP and passkeys',
+    ],
+    async fn(subcommand?: string, username?: string) {
+      const db = this.omegga.webserver?.database;
+      if (!db) {
+        err('Database not available.');
+        return;
+      }
+      if (!subcommand || !username) {
+        err('Usage: /user <passwd|resetmfa> <username>');
+        return;
+      }
+      if (!(await db.userExists(username))) {
+        err(`User "${username}" does not exist.`);
+        return;
+      }
+      switch (subcommand) {
+        case 'passwd': {
+          const password = await new Promise<string>(resolve =>
+            this.rl.question('New password: ', resolve),
+          );
+          if (!password) {
+            err('Password cannot be empty.');
+            return;
+          }
+          await db.userPasswd(username, password);
+          log(`Password updated for "${username.yellow}".`);
+          break;
+        }
+        case 'resetmfa': {
+          await db.resetUserMfa(username);
+          log(
+            `MFA cleared for "${username.yellow}" (TOTP, passkeys, recovery codes).`,
+          );
+          break;
+        }
+        default:
+          err(`Unknown subcommand "${subcommand}". Use passwd or resetmfa.`);
+      }
+    },
+  },
 ];
 
 // the terminal wraps omegga and displays console output and handles console input

--- a/src/webserver/backend/api.ts
+++ b/src/webserver/backend/api.ts
@@ -4,6 +4,8 @@
 
 import { IPluginDocumentation } from '@/plugin';
 import Database from './database';
+import type { PermissionSet } from './permissions';
+import type { Scope } from './scopes';
 import {
   IFrontendBanEntry,
   IStoreBanHistory,
@@ -30,6 +32,8 @@ export type OmeggaSocketData = {
     username: string;
     isOwner: boolean;
     roles: string[];
+    permissions: PermissionSet;
+    resolvedScopes: Record<Scope, boolean>;
   };
 };
 

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -10,11 +10,17 @@ import Datastore from 'nedb-promises';
 import path from 'path';
 import Calendar from './calendar';
 import {
+  EMPTY_PERMISSIONS,
+  RootLevel,
+  type PermissionSet,
+} from './permissions';
+import {
   IPlayer,
   IPunchcard,
   IStoreAutoRestartConfig,
   IStoreBanHistory,
   IStoreChat,
+  IStoreDefaultPermissions,
   IStoreKickHistory,
   IStoreServerInstance,
   IStoreUser,
@@ -52,6 +58,7 @@ export default class Database extends EventEmitter {
     status: Datastore;
     server: Datastore;
   };
+  defaultPermissionsCache: IStoreDefaultPermissions | null = null;
   calendar: Calendar;
 
   constructor(options: IServerConfig, omegga: Omegga) {
@@ -97,11 +104,11 @@ export default class Database extends EventEmitter {
   async doMigrations() {
     // current store versions
     const storeVersions: { [key: keyof typeof this.stores]: number } = {
-      users: 1,
+      users: 2,
       chat: 1,
       players: 1,
       status: 1,
-      server: 1,
+      server: 2,
 
       // example version
       dummy: 10,
@@ -114,11 +121,66 @@ export default class Database extends EventEmitter {
         upgrade: (store: Datastore) => Promise<void>;
       }[];
     } = {
-      users: [],
+      users: [
+        {
+          version: 1,
+          upgrade: async (store: Datastore) => {
+            const users = await store.find<IStoreUser & { _id: string }>({
+              type: 'user',
+            });
+            for (const user of users) {
+              const p = (user.permissions as any) ?? EMPTY_PERMISSIONS;
+              const root =
+                p.root === 'all' || p.root === 'read' ? p.root : 'off';
+              const domains: Record<string, string> = {};
+              for (const [k, v] of Object.entries(p.domains ?? {})) {
+                if (v !== 'unset' && v !== 'none') domains[k] = v as string;
+              }
+              const scopes: Record<string, boolean> = {};
+              for (const [k, v] of Object.entries(p.scopes ?? {})) {
+                if (v === 'enabled' || v === true) scopes[k] = true;
+                else if (v === 'disabled' || v === false) scopes[k] = false;
+              }
+              await store.update(
+                { _id: user._id },
+                {
+                  $set: {
+                    permissions: { root, domains, scopes },
+                  },
+                },
+              );
+            }
+          },
+        },
+      ],
       chat: [],
       players: [],
       status: [],
-      server: [],
+      server: [
+        {
+          version: 1,
+          upgrade: async (store: Datastore) => {
+            const doc = await store.findOne<any>({
+              type: 'defaultPermissions',
+            });
+            if (!doc) return;
+            const root = doc.root === 'unset' ? 'off' : doc.root;
+            const domains: Record<string, string> = {};
+            for (const [k, v] of Object.entries(doc.domains ?? {})) {
+              if (v !== 'unset') domains[k] = v as string;
+            }
+            const scopes: Record<string, boolean> = {};
+            for (const [k, v] of Object.entries(doc.scopes ?? {})) {
+              if (v === 'enabled') scopes[k] = true;
+              else if (v === 'disabled') scopes[k] = false;
+            }
+            await store.update(
+              { _id: doc._id },
+              { $set: { root, domains, scopes } },
+            );
+          },
+        },
+      ],
 
       // example migration list (all version upgrades go up by 1)
       dummy: [
@@ -140,8 +202,8 @@ export default class Database extends EventEmitter {
         if (!versionEntry) {
           store.insert({ type: 'storeVersion', version: expected });
 
-          // if the version was not what was expected
-        } else if (expected !== versionEntry.version) {
+          // if the version is below the expected version
+        } else if (versionEntry.version < expected) {
           // while the version is below the expected version
           let { version } = versionEntry;
           for (; version < expected; version++) {
@@ -286,6 +348,7 @@ export default class Database extends EventEmitter {
       // permissions
       isOwner: true,
       roles: [],
+      permissions: EMPTY_PERMISSIONS,
 
       // brickadia player uuid
       playerId: '',
@@ -303,7 +366,7 @@ export default class Database extends EventEmitter {
     if (await this.userExists(username)) throw new Error('user already exists');
 
     const hash = await this.hash(password);
-    // create an owner user
+    // create a regular user
     const user = this.stores.users.insert<IStoreUser>({
       // this is a user
       type: 'user',
@@ -317,6 +380,7 @@ export default class Database extends EventEmitter {
       // permissions
       isOwner: false,
       roles: [],
+      permissions: EMPTY_PERMISSIONS,
 
       // brickadia player uuid
       playerId: '',
@@ -347,6 +411,41 @@ export default class Database extends EventEmitter {
     return await this.stores.users.remove({ type: 'user', username }, {});
   }
 
+  async setUserPermissions(username: string, permissions: PermissionSet) {
+    return await this.stores.users.update(
+      { type: 'user', username },
+      { $set: { permissions } },
+    );
+  }
+
+  async getDefaultPermissions(): Promise<IStoreDefaultPermissions> {
+    if (this.defaultPermissionsCache) return this.defaultPermissionsCache;
+    let doc = await this.stores.server.findOne<IStoreDefaultPermissions>({
+      type: 'defaultPermissions',
+    });
+    if (!doc) {
+      doc = await this.stores.server.insert<IStoreDefaultPermissions>({
+        type: 'defaultPermissions',
+        root: RootLevel.Read,
+        domains: {},
+        scopes: {},
+      });
+    }
+    this.defaultPermissionsCache = doc;
+    return doc;
+  }
+
+  async setDefaultPermissions(
+    permissions: Omit<IStoreDefaultPermissions, 'type'>,
+  ) {
+    await this.stores.server.update(
+      { type: 'defaultPermissions' },
+      { $set: { ...permissions } },
+      { upsert: true },
+    );
+    this.defaultPermissionsCache = null;
+  }
+
   // get a user from credentials
   async authUser(username: string, password: string) {
     const user = await this.stores.users.findOne<IStoreUser>({ username });
@@ -369,7 +468,7 @@ export default class Database extends EventEmitter {
 
   // find a user by object id
   async findUserById(id: string) {
-    return await this.stores.users.findOne<IStoreUser>({
+    const user = await this.stores.users.findOne<IStoreUser>({
       $or: [
         // the owner has no username, so everyone is the owner
         { type: 'user', username: '', isOwner: true },
@@ -378,6 +477,10 @@ export default class Database extends EventEmitter {
         { type: 'user', _id: id },
       ],
     });
+    if (user && !user.permissions) {
+      user.permissions = EMPTY_PERMISSIONS;
+    }
+    return user;
   }
 
   // get a list of roles
@@ -604,7 +707,7 @@ export default class Database extends EventEmitter {
   }
 
   // add a user to the visit history, returns true if this is a first visit
-  async addVisit(user: IPlayer) {
+  async addVisit(user: Required<IPlayer>) {
     const existing = await this.stores.players.findOne<IUserHistory>({
       type: 'userHistory',
       id: user.id,

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -12,6 +12,8 @@ import Calendar from './calendar';
 import {
   EMPTY_PERMISSIONS,
   RootLevel,
+  decodePermissions,
+  encodePermissions,
   type PermissionSet,
 } from './permissions';
 import {
@@ -27,6 +29,7 @@ import {
   IStoreVersion,
   IUserHistory,
   IUserNote,
+  IWebAuthnCredential,
 } from './types';
 
 // TODO: online users graph
@@ -141,13 +144,10 @@ export default class Database extends EventEmitter {
                 if (v === 'enabled' || v === true) scopes[k] = true;
                 else if (v === 'disabled' || v === false) scopes[k] = false;
               }
+              const encoded = encodePermissions({ root, domains, scopes });
               await store.update(
                 { _id: user._id },
-                {
-                  $set: {
-                    permissions: { root, domains, scopes },
-                  },
-                },
+                { $set: { permissions: encoded } },
               );
             }
           },
@@ -174,9 +174,20 @@ export default class Database extends EventEmitter {
               if (v === 'enabled') scopes[k] = true;
               else if (v === 'disabled') scopes[k] = false;
             }
+            const encoded = encodePermissions({
+              root,
+              domains,
+              scopes,
+            } as PermissionSet);
             await store.update(
               { _id: doc._id },
-              { $set: { root, domains, scopes } },
+              {
+                $set: {
+                  root: encoded.root,
+                  domains: encoded.domains,
+                  scopes: encoded.scopes,
+                },
+              },
             );
           },
         },
@@ -350,6 +361,11 @@ export default class Database extends EventEmitter {
       roles: [],
       permissions: EMPTY_PERMISSIONS,
 
+      // mfa
+      totpEnabled: false,
+      passkeys: [],
+      recoveryCodes: [],
+
       // brickadia player uuid
       playerId: '',
     });
@@ -382,6 +398,11 @@ export default class Database extends EventEmitter {
       roles: [],
       permissions: EMPTY_PERMISSIONS,
 
+      // mfa
+      totpEnabled: false,
+      passkeys: [],
+      recoveryCodes: [],
+
       // brickadia player uuid
       playerId: '',
     });
@@ -392,7 +413,8 @@ export default class Database extends EventEmitter {
   async userPasswd(username: string, password: string) {
     const hash = await this.hash(password);
 
-    if (!this.userExists(username)) throw new Error('user does not exist');
+    if (!(await this.userExists(username)))
+      throw new Error('user does not exist');
 
     await this.stores.users.update(
       { type: 'user', username },
@@ -414,7 +436,7 @@ export default class Database extends EventEmitter {
   async setUserPermissions(username: string, permissions: PermissionSet) {
     return await this.stores.users.update(
       { type: 'user', username },
-      { $set: { permissions } },
+      { $set: { permissions: encodePermissions(permissions) } },
     );
   }
 
@@ -431,16 +453,25 @@ export default class Database extends EventEmitter {
         scopes: {},
       });
     }
-    this.defaultPermissionsCache = doc;
-    return doc;
+    const decoded = decodePermissions(doc);
+    const result = { ...doc, ...decoded };
+    this.defaultPermissionsCache = result;
+    return result;
   }
 
   async setDefaultPermissions(
     permissions: Omit<IStoreDefaultPermissions, 'type'>,
   ) {
+    const encoded = encodePermissions(permissions as PermissionSet);
     await this.stores.server.update(
       { type: 'defaultPermissions' },
-      { $set: { ...permissions } },
+      {
+        $set: {
+          root: encoded.root,
+          domains: encoded.domains,
+          scopes: encoded.scopes,
+        },
+      },
       { upsert: true },
     );
     this.defaultPermissionsCache = null;
@@ -477,10 +508,100 @@ export default class Database extends EventEmitter {
         { type: 'user', _id: id },
       ],
     });
-    if (user && !user.permissions) {
-      user.permissions = EMPTY_PERMISSIONS;
+    if (user) {
+      user.permissions = decodePermissions(user.permissions);
+      if (!user.totpEnabled) user.totpEnabled = false;
+      if (!user.passkeys) user.passkeys = [];
     }
     return user;
+  }
+
+  async setUserTotp(username: string, secret: string, enabled: boolean) {
+    await this.stores.users.update(
+      { type: 'user', username },
+      { $set: { totpSecret: secret, totpEnabled: enabled } },
+    );
+  }
+
+  async disableUserTotp(username: string) {
+    await this.stores.users.update(
+      { type: 'user', username },
+      { $set: { totpEnabled: false }, $unset: { totpSecret: true } },
+    );
+  }
+
+  async addPasskey(username: string, credential: IWebAuthnCredential) {
+    await this.stores.users.update(
+      { type: 'user', username },
+      { $push: { passkeys: credential } },
+    );
+  }
+
+  async removePasskey(username: string, credentialId: string) {
+    const user = await this.stores.users.findOne<IStoreUser & { _id: string }>({
+      type: 'user',
+      username,
+    });
+    if (!user) return;
+    const passkeys = (user.passkeys ?? []).filter(p => p.id !== credentialId);
+    await this.stores.users.update({ _id: user._id }, { $set: { passkeys } });
+  }
+
+  async updatePasskeyCounter(
+    username: string,
+    credentialId: string,
+    counter: number,
+  ) {
+    const user = await this.stores.users.findOne<IStoreUser & { _id: string }>({
+      type: 'user',
+      username,
+    });
+    if (!user) return;
+    const passkeys = (user.passkeys ?? []).map(p =>
+      p.id === credentialId ? { ...p, counter, lastUsed: Date.now() } : p,
+    );
+    await this.stores.users.update({ _id: user._id }, { $set: { passkeys } });
+  }
+
+  async setRecoveryCodes(username: string, hashedCodes: string[]) {
+    await this.stores.users.update(
+      { type: 'user', username },
+      { $set: { recoveryCodes: hashedCodes } },
+    );
+  }
+
+  async removeRecoveryCode(username: string, hashedCode: string) {
+    const user = await this.stores.users.findOne<IStoreUser & { _id: string }>({
+      type: 'user',
+      username,
+    });
+    if (!user) return;
+    const codes = (user.recoveryCodes ?? []).filter(c => c !== hashedCode);
+    await this.stores.users.update(
+      { _id: user._id },
+      { $set: { recoveryCodes: codes } },
+    );
+  }
+
+  async resetUserMfa(username: string) {
+    await this.stores.users.update(
+      { type: 'user', username },
+      {
+        $set: {
+          totpEnabled: false,
+          passkeys: [],
+          recoveryCodes: [],
+        },
+        $unset: { totpSecret: true },
+      },
+    );
+  }
+
+  async findUserByPasskeyId(credentialId: string) {
+    return await this.stores.users.findOne<IStoreUser & { _id: string }>({
+      type: 'user',
+      'passkeys.id': credentialId,
+    });
   }
 
   // get a list of roles

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -336,6 +336,17 @@ export default class Database extends EventEmitter {
     );
   }
 
+  async banUser(username: string, banned: boolean) {
+    return await this.stores.users.update(
+      { type: 'user', username },
+      { $set: { isBanned: banned } },
+    );
+  }
+
+  async deleteUser(username: string) {
+    return await this.stores.users.remove({ type: 'user', username }, {});
+  }
+
   // get a user from credentials
   async authUser(username: string, password: string) {
     const user = await this.stores.users.findOne<IStoreUser>({ username });

--- a/src/webserver/backend/database.ts
+++ b/src/webserver/backend/database.ts
@@ -9,6 +9,7 @@ import EventEmitter from 'events';
 import Datastore from 'nedb-promises';
 import path from 'path';
 import Calendar from './calendar';
+import { serverEvents } from './events';
 import {
   EMPTY_PERMISSIONS,
   RootLevel,
@@ -423,14 +424,21 @@ export default class Database extends EventEmitter {
   }
 
   async banUser(username: string, banned: boolean) {
-    return await this.stores.users.update(
+    const result = await this.stores.users.update(
       { type: 'user', username },
       { $set: { isBanned: banned } },
     );
+    if (banned) serverEvents.emit('userInvalidated', username);
+    return result;
   }
 
   async deleteUser(username: string) {
-    return await this.stores.users.remove({ type: 'user', username }, {});
+    const result = await this.stores.users.remove(
+      { type: 'user', username },
+      {},
+    );
+    serverEvents.emit('userInvalidated', username);
+    return result;
   }
 
   async setUserPermissions(username: string, permissions: PermissionSet) {

--- a/src/webserver/backend/events.ts
+++ b/src/webserver/backend/events.ts
@@ -4,4 +4,4 @@ import { EventEmitter } from 'events';
 // Producers (metrics.ts, omegga event handlers) emit here;
 // subscription resolvers in the router consume these events.
 export const serverEvents = new EventEmitter();
-serverEvents.setMaxListeners(50);
+serverEvents.setMaxListeners(200);

--- a/src/webserver/backend/index.ts
+++ b/src/webserver/backend/index.ts
@@ -41,7 +41,7 @@ export default class Webserver {
   created: Promise<boolean>;
 
   serverStatusInterval: ReturnType<typeof setInterval>;
-  lastReportedStatus: IServerStatus;
+  lastReportedStatus: IServerStatus | null = null;
 
   dataPath: string;
 

--- a/src/webserver/backend/index.ts
+++ b/src/webserver/backend/index.ts
@@ -12,7 +12,13 @@ import http from 'http';
 import https from 'https';
 import NedbStore from 'nedb-promises-session-store';
 import path from 'path';
+import bcrypt from 'bcryptjs';
+import {
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
 import Database from './database';
+import { verifyToken as verifyTOTP } from './totp';
 import setupMetrics from './metrics';
 import { appRouter } from './router';
 import { setWebserver } from './router/server';
@@ -192,16 +198,151 @@ export default class Webserver {
 
       if (user) {
         req.session.userId = user._id;
-        req.session.save();
-        res.status(200).json({});
+        if (user.totpEnabled) {
+          req.session.mfaPending = true;
+          req.session.save();
+          res.status(200).json({ mfaRequired: true });
+        } else {
+          req.session.save();
+          res.status(200).json({});
+        }
       } else {
         res.status(404).json({ message: 'no user found' });
+      }
+    });
+
+    // rate limiting for MFA verification (per session)
+    const mfaAttempts = new Map<
+      string,
+      { count: number; lockedUntil: number }
+    >();
+
+    // TOTP verification during MFA challenge
+    openApi.post('/auth/mfa/totp', async (req, res) => {
+      if (!req.session.mfaPending || !req.session.userId) {
+        return res.status(400).json({ message: 'no pending MFA challenge' });
+      }
+
+      // rate limit: 5 attempts, then 60s lockout
+      const sid = req.sessionID;
+      const attempt = mfaAttempts.get(sid) ?? { count: 0, lockedUntil: 0 };
+      if (Date.now() < attempt.lockedUntil) {
+        return res
+          .status(429)
+          .json({ message: 'too many attempts, try again later' });
+      }
+
+      const { code } = req.body ?? {};
+      if (typeof code !== 'string') {
+        return res.status(422).json({ message: 'code required' });
+      }
+      const user = await this.database.findUserById(req.session.userId);
+      if (!user || !user.totpSecret) {
+        return res.status(400).json({ message: 'MFA not configured' });
+      }
+
+      let verified = false;
+
+      if (verifyTOTP(code, user.totpSecret)) {
+        verified = true;
+      }
+
+      // try recovery codes
+      if (!verified && user.recoveryCodes?.length) {
+        for (const hashedCode of user.recoveryCodes) {
+          if (await bcrypt.compare(code, hashedCode)) {
+            await this.database.removeRecoveryCode(user.username, hashedCode);
+            verified = true;
+            break;
+          }
+        }
+      }
+
+      if (verified) {
+        mfaAttempts.delete(sid);
+        delete req.session.mfaPending;
+        req.session.save();
+        return res.status(200).json({});
+      }
+
+      attempt.count++;
+      if (attempt.count >= 5) {
+        attempt.lockedUntil = Date.now() + 60_000;
+        attempt.count = 0;
+      }
+      mfaAttempts.set(sid, attempt);
+      res.status(401).json({ message: 'invalid code' });
+    });
+
+    const getRpID = (req: express.Request) => {
+      const origin = req.headers.origin;
+      if (origin) {
+        try {
+          return new URL(origin as string).hostname;
+        } catch {}
+      }
+      return req.hostname;
+    };
+
+    // WebAuthn authentication options (passwordless login)
+    openApi.get('/auth/webauthn/options', async (req, res) => {
+      const rpID = getRpID(req);
+      const options = await generateAuthenticationOptions({ rpID });
+      req.session.mfaChallenge = options.challenge;
+      req.session.save();
+      res.json(options);
+    });
+
+    // WebAuthn authentication verification
+    openApi.post('/auth/webauthn/verify', async (req, res) => {
+      const challenge = req.session.mfaChallenge;
+      if (!challenge) {
+        return res.status(400).json({ message: 'no pending challenge' });
+      }
+      // clear challenge immediately to prevent replay
+      delete req.session.mfaChallenge;
+      req.session.save();
+      try {
+        const { credential } = req.body;
+        const user = await this.database.findUserByPasskeyId(credential?.id);
+        if (!user || user.isBanned) {
+          return res.status(401).json({ message: 'unknown credential' });
+        }
+        const passkey = user.passkeys!.find(p => p.id === credential.id)!;
+        const verification = await verifyAuthenticationResponse({
+          response: credential,
+          expectedChallenge: challenge,
+          expectedOrigin:
+            req.headers.origin ?? `${req.protocol}://${req.get('host')}`,
+          expectedRPID: getRpID(req),
+          credential: {
+            id: passkey.id,
+            publicKey: Buffer.from(passkey.publicKey, 'base64url'),
+            counter: passkey.counter,
+            transports: passkey.transports as any,
+          },
+        });
+        if (!verification.verified) {
+          return res.status(401).json({ message: 'verification failed' });
+        }
+        await this.database.updatePasskeyCounter(
+          user.username,
+          passkey.id,
+          verification.authenticationInfo.newCounter,
+        );
+        req.session.userId = (user as any)._id;
+        delete req.session.mfaPending;
+        req.session.save();
+        res.status(200).json({});
+      } catch (e) {
+        res.status(400).json({ message: 'verification error' });
       }
     });
 
     // authentication middleware for protected api routes
     api.all('*', (req, _res, next) => {
       (async () => {
+        if (req.session.mfaPending) return next(new Error('unauthorized'));
         const user = await this.database.findUserById(req.session.userId);
         if (!user || user.isBanned) return next(new Error('unauthorized'));
         next();
@@ -232,6 +373,9 @@ export default class Webserver {
 
     // every request goes through the index file (frontend handles 404s)
     this.app.use(async (req, res) => {
+      if (req.session.mfaPending) {
+        return res.sendFile(path.join(PUBLIC_PATH, 'auth.html'));
+      }
       const user = await this.database.findUserById(req.session.userId);
       const isAuth = user && !user.isBanned;
       if (isAuth) {

--- a/src/webserver/backend/permissions.ts
+++ b/src/webserver/backend/permissions.ts
@@ -24,6 +24,44 @@ export const EMPTY_PERMISSIONS: PermissionSet = {
   scopes: {},
 };
 
+// NeDB rejects field names containing dots, so we encode/decode
+// scope keys (e.g. "server.status") for storage
+const DOT_ENCODE = /\./g;
+const DOT_DECODE = /:/g;
+
+function encodeKeys<V>(obj: Record<string, V>): Record<string, V> {
+  const out: Record<string, V> = {};
+  for (const [k, v] of Object.entries(obj)) out[k.replace(DOT_ENCODE, ':')] = v;
+  return out;
+}
+
+function decodeKeys<V>(obj: Record<string, V>): Record<string, V> {
+  const out: Record<string, V> = {};
+  for (const [k, v] of Object.entries(obj)) out[k.replace(DOT_DECODE, '.')] = v;
+  return out;
+}
+
+export interface StoredPermissionSet {
+  root: RootLevel;
+  domains: Partial<Record<string, DomainLevel>>;
+  scopes: Record<string, boolean>;
+}
+
+export function encodePermissions(p: PermissionSet): StoredPermissionSet {
+  return { root: p.root, domains: p.domains, scopes: encodeKeys(p.scopes) };
+}
+
+export function decodePermissions(
+  p: StoredPermissionSet | null | undefined,
+): PermissionSet {
+  if (!p) return EMPTY_PERMISSIONS;
+  return {
+    root: p.root ?? RootLevel.Off,
+    domains: p.domains ?? {},
+    scopes: decodeKeys(p.scopes ?? {}),
+  };
+}
+
 const ALL_SCOPES = Object.keys(SCOPES) as Scope[];
 
 export function resolveScope(

--- a/src/webserver/backend/permissions.ts
+++ b/src/webserver/backend/permissions.ts
@@ -1,0 +1,80 @@
+import { SCOPES, ScopeName, type Domain, type Scope } from './scopes';
+
+export enum RootLevel {
+  All = 'all',
+  Read = 'read',
+  Off = 'off',
+}
+
+export enum DomainLevel {
+  All = 'all',
+  Read = 'read',
+  None = 'none',
+}
+
+export interface PermissionSet {
+  root: RootLevel;
+  domains: Partial<Record<Domain, DomainLevel>>;
+  scopes: Partial<Record<Scope, boolean>>;
+}
+
+export const EMPTY_PERMISSIONS: PermissionSet = {
+  root: RootLevel.Off,
+  domains: {},
+  scopes: {},
+};
+
+const ALL_SCOPES = Object.keys(SCOPES) as Scope[];
+
+export function resolveScope(
+  userPerms: PermissionSet,
+  defaultPerms: PermissionSet | null,
+  scopeName: Scope,
+): boolean {
+  if (scopeName === ScopeName.SessionInfo) return true;
+
+  const scopeDef = SCOPES[scopeName];
+
+  // 1. Root
+  if (userPerms.root === RootLevel.All) return true;
+  if (userPerms.root === RootLevel.Read) return scopeDef.readOnly;
+
+  // 2. Domain
+  const domain = userPerms.domains[scopeDef.domain as Domain];
+  if (domain === DomainLevel.All) return true;
+  if (domain === DomainLevel.Read) return scopeDef.readOnly;
+
+  // 3. Scope
+  const scopeVal = userPerms.scopes[scopeName];
+  if (scopeVal === true) return true;
+  if (scopeVal === false) return false;
+
+  // 4. Fall back to defaults
+  if (defaultPerms) return resolveScope(defaultPerms, null, scopeName);
+
+  return false;
+}
+
+export function resolveAllScopes(
+  userPerms: PermissionSet,
+  defaultPerms: PermissionSet | null,
+): Record<Scope, boolean> {
+  const result = {} as Record<Scope, boolean>;
+  for (const scope of ALL_SCOPES) {
+    result[scope] = resolveScope(userPerms, defaultPerms, scope);
+  }
+  return result;
+}
+
+export function userHasScope(
+  user: { isOwner: boolean; permissions?: PermissionSet },
+  scope: Scope,
+  defaultPerms: PermissionSet | null,
+): boolean {
+  if (user.isOwner) return true;
+  return resolveScope(
+    user.permissions ?? EMPTY_PERMISSIONS,
+    defaultPerms,
+    scope,
+  );
+}

--- a/src/webserver/backend/permissions.ts
+++ b/src/webserver/backend/permissions.ts
@@ -82,10 +82,9 @@ export function resolveScope(
   if (domain === DomainLevel.All) return true;
   if (domain === DomainLevel.Read) return scopeDef.readOnly;
 
-  // 3. Scope
+  // 3. Scope (additive only - explicit true grants, false/absent falls through)
   const scopeVal = userPerms.scopes[scopeName];
   if (scopeVal === true) return true;
-  if (scopeVal === false) return false;
 
   // 4. Fall back to defaults
   if (defaultPerms) return resolveScope(defaultPerms, null, scopeName);

--- a/src/webserver/backend/router/chat.ts
+++ b/src/webserver/backend/router/chat.ts
@@ -57,9 +57,10 @@ export const chatRouter = router({
     }),
 
     onMessage: protectedProcedure(ScopeName.ChatRecent).subscription(
-      async function* ({ signal }) {
+      async function* ({ signal, ctx }) {
+        const combined = AbortSignal.any([signal!, ctx.userAbort.signal]);
         for await (const [chatLog] of on(serverEvents, 'chat', {
-          signal,
+          signal: combined,
         })) {
           yield chatLog;
         }

--- a/src/webserver/backend/router/chat.ts
+++ b/src/webserver/backend/router/chat.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod/v4';
 import { on } from 'events';
 import { router, protectedProcedure, getContextDeps } from '../trpc';
+import { ScopeName } from '../scopes';
 import { serverEvents } from '../events';
 import Logger from '@/logger';
 import { parseLinks, sanitize } from '@util/chat';
 
 export const chatRouter = router({
   chat: router({
-    send: protectedProcedure('chat.send')
+    send: protectedProcedure(ScopeName.ChatSend)
       .input(z.string())
       .mutation(async ({ input: message, ctx }) => {
         const { database, omegga } = getContextDeps();
@@ -33,12 +34,12 @@ export const chatRouter = router({
         return 'ok';
       }),
 
-    recent: protectedProcedure('chat.recent').query(() => {
+    recent: protectedProcedure(ScopeName.ChatRecent).query(() => {
       const { database } = getContextDeps();
       return database.getChats({ sameServer: true });
     }),
 
-    history: protectedProcedure('chat.history')
+    history: protectedProcedure(ScopeName.ChatHistory)
       .input(
         z.object({
           after: z.number().optional(),
@@ -50,12 +51,12 @@ export const chatRouter = router({
         return database.getChats({ after: input.after, before: input.before });
       }),
 
-    calendar: protectedProcedure('chat.calendar').query(() => {
+    calendar: protectedProcedure(ScopeName.ChatCalendar).query(() => {
       const { database } = getContextDeps();
       return database.calendar.years;
     }),
 
-    onMessage: protectedProcedure('chat.onMessage').subscription(
+    onMessage: protectedProcedure(ScopeName.ChatRecent).subscription(
       async function* ({ signal }) {
         for await (const [chatLog] of on(serverEvents, 'chat', {
           signal,

--- a/src/webserver/backend/router/index.ts
+++ b/src/webserver/backend/router/index.ts
@@ -1,5 +1,6 @@
 import { mergeRouters } from '../trpc';
 import { chatRouter } from './chat';
+import { mfaRouter } from './mfa';
 import { playerRouter } from './player';
 import { pluginRouter } from './plugin';
 import { roleRouter } from './role';
@@ -17,6 +18,7 @@ export const appRouter = mergeRouters(
   userRouter,
   worldRouter,
   roleRouter,
+  mfaRouter,
 );
 
 export type AppRouter = typeof appRouter;

--- a/src/webserver/backend/router/mfa.ts
+++ b/src/webserver/backend/router/mfa.ts
@@ -1,0 +1,186 @@
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+import QRCode from 'qrcode';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import { z } from 'zod/v4';
+import { ScopeName } from '../scopes';
+import { generateSecret, generateURI, verifyToken } from '../totp';
+import { getContextDeps, protectedProcedure, router } from '../trpc';
+
+function getRpID(req: import('express').Request): string {
+  const origin = req.headers.origin;
+  if (origin) {
+    try {
+      return new URL(origin).hostname;
+    } catch {}
+  }
+  return req.hostname;
+}
+
+async function requirePassword(ctx: any, password: string): Promise<boolean> {
+  return bcrypt.compare(password, ctx.user.hash);
+}
+
+export const mfaRouter = router({
+  mfa: router({
+    status: protectedProcedure(ScopeName.SessionInfo).query(({ ctx }) => {
+      const user = ctx.user;
+      return {
+        totpEnabled: user.totpEnabled ?? false,
+        passkeys: (user.passkeys ?? []).map(p => ({
+          id: p.id,
+          name: p.name,
+          created: p.created,
+          lastUsed: p.lastUsed,
+        })),
+        hasRecoveryCodes: (user.recoveryCodes?.length ?? 0) > 0,
+      };
+    }),
+
+    totp: router({
+      setup: protectedProcedure(ScopeName.SessionInfo)
+        .input(z.object({ password: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+          if (!(await requirePassword(ctx, input.password))) {
+            return { error: 'incorrect password' };
+          }
+          const secret = generateSecret();
+          const uri = generateURI(secret, ctx.user.username || 'Admin');
+          const qrCode = await QRCode.toDataURL(uri);
+          // store secret in session so enable can't accept arbitrary secrets
+          (ctx.req as any).session.pendingTotpSecret = secret;
+          (ctx.req as any).session.save();
+          return { secret, uri, qrCode };
+        }),
+
+      enable: protectedProcedure(ScopeName.SessionInfo)
+        .input(z.object({ code: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          const secret = (ctx.req as any).session.pendingTotpSecret;
+          if (!secret) return 'no pending TOTP setup';
+          if (!verifyToken(input.code, secret)) {
+            return 'invalid code';
+          }
+          await database.setUserTotp(ctx.user.username, secret, true);
+          delete (ctx.req as any).session.pendingTotpSecret;
+          (ctx.req as any).session.save();
+          return '';
+        }),
+
+      disable: protectedProcedure(ScopeName.SessionInfo)
+        .input(z.object({ password: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          if (!(await requirePassword(ctx, input.password))) {
+            return 'incorrect password';
+          }
+          await database.disableUserTotp(ctx.user.username);
+          return '';
+        }),
+    }),
+
+    passkey: router({
+      registerOptions: protectedProcedure(ScopeName.SessionInfo).mutation(
+        async ({ ctx }) => {
+          const rpID = getRpID(ctx.req);
+          const options = await generateRegistrationOptions({
+            rpName: 'Omegga',
+            rpID,
+            userName: ctx.user.username || 'Admin',
+            excludeCredentials: (ctx.user.passkeys ?? []).map(p => ({
+              id: p.id,
+              transports: p.transports as any,
+            })),
+            authenticatorSelection: {
+              residentKey: 'preferred',
+              userVerification: 'preferred',
+            },
+          });
+          (ctx.req as any).session.mfaChallenge = options.challenge;
+          (ctx.req as any).session.save();
+          return options;
+        },
+      ),
+
+      register: protectedProcedure(ScopeName.SessionInfo)
+        .input(
+          z.object({
+            credential: z.any(),
+            name: z.string().max(64).default('Passkey'),
+          }),
+        )
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          const challenge = (ctx.req as any).session.mfaChallenge;
+          if (!challenge) return 'no pending challenge';
+          // clear challenge immediately to prevent replay
+          delete (ctx.req as any).session.mfaChallenge;
+          (ctx.req as any).session.save();
+          try {
+            const verification = await verifyRegistrationResponse({
+              response: input.credential,
+              expectedChallenge: challenge,
+              expectedOrigin:
+                ctx.req.headers.origin ??
+                `${ctx.req.protocol}://${ctx.req.get('host')}`,
+              expectedRPID: getRpID(ctx.req),
+            });
+            if (!verification.verified || !verification.registrationInfo) {
+              return 'verification failed';
+            }
+            const { credential } = verification.registrationInfo;
+            await database.addPasskey(ctx.user.username, {
+              id: credential.id,
+              publicKey: Buffer.from(credential.publicKey).toString(
+                'base64url',
+              ),
+              counter: credential.counter,
+              name: input.name,
+              created: Date.now(),
+              lastUsed: 0,
+              transports: input.credential.response?.transports,
+            });
+            return '';
+          } catch (e) {
+            console.error('Passkey registration error:', e);
+            return 'registration failed';
+          }
+        }),
+
+      remove: protectedProcedure(ScopeName.SessionInfo)
+        .input(z.object({ id: z.string(), password: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          if (!(await requirePassword(ctx, input.password))) {
+            return 'incorrect password';
+          }
+          await database.removePasskey(ctx.user.username, input.id);
+          return '';
+        }),
+    }),
+
+    recoveryCodes: router({
+      generate: protectedProcedure(ScopeName.SessionInfo)
+        .input(z.object({ password: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          if (!(await requirePassword(ctx, input.password))) {
+            return { error: 'incorrect password' };
+          }
+          const codes: string[] = [];
+          const hashes: string[] = [];
+          for (let i = 0; i < 10; i++) {
+            const code = crypto.randomBytes(5).toString('hex');
+            codes.push(code);
+            hashes.push(await bcrypt.hash(code, 10));
+          }
+          await database.setRecoveryCodes(ctx.user.username, hashes);
+          return { codes };
+        }),
+    }),
+  }),
+});

--- a/src/webserver/backend/router/player.ts
+++ b/src/webserver/backend/router/player.ts
@@ -4,13 +4,14 @@ import { parseBrickadiaTime } from '@util/time';
 import * as uuid from '@util/uuid';
 import _ from 'lodash';
 import { z } from 'zod/v4';
+import { ScopeName } from '../scopes';
 import { getContextDeps, protectedProcedure, router } from '../trpc';
 import type { IStoreBanHistory, IStoreKickHistory } from '../types';
 import { waitForEvent } from '../util';
 
 export const playerRouter = router({
   player: router({
-    list: protectedProcedure('player.list')
+    list: protectedProcedure(ScopeName.PlayerList)
       .input(
         z.object({
           page: z.number().optional().default(0),
@@ -81,7 +82,7 @@ export const playerRouter = router({
         return { ...resp, players };
       }),
 
-    get: protectedProcedure('player.get')
+    get: protectedProcedure(ScopeName.PlayerGet)
       .input(z.string())
       .query(async ({ input: id }) => {
         const { database, omegga } = getContextDeps();
@@ -162,7 +163,7 @@ export const playerRouter = router({
         };
       }),
 
-    ban: protectedProcedure('player.ban')
+    ban: protectedProcedure(ScopeName.PlayerBan)
       .input(
         z.object({
           id: z.string(),
@@ -206,7 +207,7 @@ export const playerRouter = router({
         return !!ban;
       }),
 
-    kick: protectedProcedure('player.kick')
+    kick: protectedProcedure(ScopeName.PlayerKick)
       .input(
         z.object({
           id: z.string(),
@@ -245,7 +246,7 @@ export const playerRouter = router({
         return ok;
       }),
 
-    unban: protectedProcedure('player.unban')
+    unban: protectedProcedure(ScopeName.PlayerUnban)
       .input(z.object({ id: z.string() }))
       .mutation(async ({ input, ctx }) => {
         const { database, omegga } = getContextDeps();
@@ -268,7 +269,7 @@ export const playerRouter = router({
         return ok;
       }),
 
-    clearBricks: protectedProcedure('player.clearBricks')
+    clearBricks: protectedProcedure(ScopeName.PlayerClearBricks)
       .input(z.object({ id: z.string() }))
       .mutation(async ({ input, ctx }) => {
         const { omegga } = getContextDeps();

--- a/src/webserver/backend/router/plugin.ts
+++ b/src/webserver/backend/router/plugin.ts
@@ -171,8 +171,11 @@ export const pluginRouter = router({
       }),
 
     onStatus: protectedProcedure(ScopeName.PluginList).subscription(
-      async function* () {
-        for await (const [payload] of on(serverEvents, 'plugin')) {
+      async function* ({ signal, ctx }) {
+        const combined = AbortSignal.any([signal!, ctx.userAbort.signal]);
+        for await (const [payload] of on(serverEvents, 'plugin', {
+          signal: combined,
+        })) {
           yield payload as {
             shortPath: string;
             name: string;

--- a/src/webserver/backend/router/plugin.ts
+++ b/src/webserver/backend/router/plugin.ts
@@ -2,12 +2,13 @@ import { z } from 'zod/v4';
 import _ from 'lodash';
 import { Plugin } from '@omegga/plugin/interface';
 import { router, protectedProcedure, getContextDeps } from '../trpc';
+import { ScopeName } from '../scopes';
 import { serverEvents } from '../events';
 import { on } from 'events';
 
 export const pluginRouter = router({
   plugin: router({
-    list: protectedProcedure('plugin.list').query(() => {
+    list: protectedProcedure(ScopeName.PluginList).query(() => {
       const { omegga } = getContextDeps();
       return _.sortBy(
         omegga.pluginLoader.plugins.map(p => ({
@@ -21,7 +22,7 @@ export const pluginRouter = router({
       );
     }),
 
-    get: protectedProcedure('plugin.get')
+    get: protectedProcedure(ScopeName.PluginGet)
       .input(z.object({ shortPath: z.string() }))
       .query(async ({ input }) => {
         const { omegga } = getContextDeps();
@@ -50,7 +51,7 @@ export const pluginRouter = router({
         };
       }),
 
-    config: protectedProcedure('plugin.config')
+    config: protectedProcedure(ScopeName.PluginConfig)
       .input(
         z.object({
           shortPath: z.string(),
@@ -68,7 +69,7 @@ export const pluginRouter = router({
         return true;
       }),
 
-    reloadAll: protectedProcedure('plugin.reloadAll').mutation(
+    reloadAll: protectedProcedure(ScopeName.PluginReloadAll).mutation(
       async ({ ctx }) => {
         const { omegga } = getContextDeps();
         const { log, error } = ctx;
@@ -107,7 +108,7 @@ export const pluginRouter = router({
       },
     ),
 
-    unload: protectedProcedure('plugin.unload')
+    unload: protectedProcedure(ScopeName.PluginUnload)
       .input(z.object({ shortPath: z.string() }))
       .mutation(async ({ input, ctx }) => {
         const { omegga } = getContextDeps();
@@ -123,7 +124,7 @@ export const pluginRouter = router({
         return await plugin.unload();
       }),
 
-    load: protectedProcedure('plugin.load')
+    load: protectedProcedure(ScopeName.PluginLoad)
       .input(z.object({ shortPath: z.string() }))
       .mutation(async ({ input, ctx }) => {
         const { omegga } = getContextDeps();
@@ -139,7 +140,7 @@ export const pluginRouter = router({
         return await plugin.load();
       }),
 
-    toggle: protectedProcedure('plugin.toggle')
+    toggle: protectedProcedure(ScopeName.PluginToggle)
       .input(z.object({ shortPath: z.string(), enabled: z.boolean() }))
       .mutation(({ input, ctx }) => {
         const { omegga } = getContextDeps();
@@ -169,7 +170,7 @@ export const pluginRouter = router({
         }
       }),
 
-    onStatus: protectedProcedure('plugin.onStatus').subscription(
+    onStatus: protectedProcedure(ScopeName.PluginList).subscription(
       async function* () {
         for await (const [payload] of on(serverEvents, 'plugin')) {
           yield payload as {

--- a/src/webserver/backend/router/role.ts
+++ b/src/webserver/backend/router/role.ts
@@ -1,9 +1,10 @@
 import _ from 'lodash';
 import { router, protectedProcedure, getContextDeps } from '../trpc';
+import { ScopeName } from '../scopes';
 
 export const roleRouter = router({
   role: router({
-    list: protectedProcedure('role.list').query(() => {
+    list: protectedProcedure(ScopeName.RoleList).query(() => {
       const { omegga } = getContextDeps();
       return _.sortBy(omegga.getRoleSetup()?.roles ?? [], p =>
         p.name.toLowerCase(),

--- a/src/webserver/backend/router/server.ts
+++ b/src/webserver/backend/router/server.ts
@@ -6,6 +6,7 @@ import { z } from 'zod/v4';
 import { serverEvents } from '../events';
 import type Webserver from '../index';
 import { getLastUtilization } from '../metrics';
+import { ScopeName } from '../scopes';
 import { getContextDeps, protectedProcedure, router } from '../trpc';
 
 let _server: Webserver | null = null;
@@ -32,12 +33,14 @@ const autoRestartConfigSchema = z.object({
 export const serverRouter = router({
   server: router({
     autoRestart: router({
-      get: protectedProcedure('server.autorestart.get').query(async () => {
-        const { database } = getContextDeps();
-        return await database.getAutoRestartConfig();
-      }),
+      get: protectedProcedure(ScopeName.ServerAutorestartGet).query(
+        async () => {
+          const { database } = getContextDeps();
+          return await database.getAutoRestartConfig();
+        },
+      ),
 
-      set: protectedProcedure('server.autorestart.set')
+      set: protectedProcedure(ScopeName.ServerAutorestartSet)
         .input(autoRestartConfigSchema)
         .mutation(async ({ input: config }) => {
           const { database } = getContextDeps();
@@ -73,15 +76,15 @@ export const serverRouter = router({
         }),
     }),
 
-    status: protectedProcedure('server.status').query(() => {
+    status: protectedProcedure(ScopeName.ServerStatus).query(() => {
       return _server?.lastReportedStatus ?? null;
     }),
 
-    utilization: protectedProcedure('server.utilization').query(() => {
+    utilization: protectedProcedure(ScopeName.ServerUtilization).query(() => {
       return getLastUtilization();
     }),
 
-    started: protectedProcedure('server.started').query(() => {
+    started: protectedProcedure(ScopeName.ServerStatus).query(() => {
       const { omegga } = getContextDeps();
       return {
         started: omegga.started,
@@ -90,47 +93,51 @@ export const serverRouter = router({
       };
     }),
 
-    start: protectedProcedure('server.start').mutation(async ({ ctx }) => {
-      const { omegga } = getContextDeps();
-      if (omegga.starting || omegga.stopping || omegga.started) return;
-      ctx.log('Starting server...');
-      await omegga.start();
-    }),
+    start: protectedProcedure(ScopeName.ServerStart).mutation(
+      async ({ ctx }) => {
+        const { omegga } = getContextDeps();
+        if (omegga.starting || omegga.stopping || omegga.started) return;
+        ctx.log('Starting server...');
+        await omegga.start();
+      },
+    ),
 
-    stop: protectedProcedure('server.stop').mutation(async ({ ctx }) => {
+    stop: protectedProcedure(ScopeName.ServerStop).mutation(async ({ ctx }) => {
       const { omegga } = getContextDeps();
       if (omegga.starting || omegga.stopping || !omegga.started) return;
       ctx.log('Stopping server...');
       await omegga.stop();
     }),
 
-    restart: protectedProcedure('server.restart').mutation(async ({ ctx }) => {
-      const { database, omegga } = getContextDeps();
-      if (omegga.starting || omegga.stopping) return;
+    restart: protectedProcedure(ScopeName.ServerRestart).mutation(
+      async ({ ctx }) => {
+        const { database, omegga } = getContextDeps();
+        if (omegga.starting || omegga.stopping) return;
 
-      try {
-        const config = await database.getAutoRestartConfig();
-        await omegga.saveServer({
-          players: config.playersEnabled,
-          saveWorld: config.saveWorld ?? true,
-          announcement: config.announcementEnabled,
-        });
-      } catch (err) {
-        ctx.error('Error while saving server setup', err);
-      }
+        try {
+          const config = await database.getAutoRestartConfig();
+          await omegga.saveServer({
+            players: config.playersEnabled,
+            saveWorld: config.saveWorld ?? true,
+            announcement: config.announcementEnabled,
+          });
+        } catch (err) {
+          ctx.error('Error while saving server setup', err);
+        }
 
-      database.addChatLog('server', {}, 'Restarting in 5 seconds...');
-      Logger.logp('Restarting in 5 seconds...');
-      omegga.broadcast(
-        `<size="20">Server restart in <b><color="ffffbb">${5} seconds</></></>`,
-      );
+        database.addChatLog('server', {}, 'Restarting in 5 seconds...');
+        Logger.logp('Restarting in 5 seconds...');
+        omegga.broadcast(
+          `<size="20">Server restart in <b><color="ffffbb">${5} seconds</></></>`,
+        );
 
-      await new Promise(resolve => setTimeout(resolve, 5000));
-      await omegga.restartServer();
-    }),
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        await omegga.restartServer();
+      },
+    ),
 
     update: router({
-      check: protectedProcedure('server.update.check').query(async () => {
+      check: protectedProcedure(ScopeName.ServerUpdateCheck).query(async () => {
         const { omegga } = getContextDeps();
         if (!omegga.config.__STEAM) return null;
 
@@ -144,40 +151,42 @@ export const serverRouter = router({
         return await hasSteamUpdate(omegga.config.server?.steambeta);
       }),
 
-      run: protectedProcedure('server.update.run').mutation(async ({ ctx }) => {
-        const { omegga } = getContextDeps();
-        if (!omegga.config.__STEAM) return false;
-        if (omegga.stopping || omegga.starting) return false;
+      run: protectedProcedure(ScopeName.ServerUpdateRun).mutation(
+        async ({ ctx }) => {
+          const { omegga } = getContextDeps();
+          if (!omegga.config.__STEAM) return false;
+          if (omegga.stopping || omegga.starting) return false;
 
-        const wasStarted = omegga.started;
-        if (wasStarted) {
-          ctx.log('Stopping server to update...');
-          await omegga.stop();
-        }
+          const wasStarted = omegga.started;
+          if (wasStarted) {
+            ctx.log('Stopping server to update...');
+            await omegga.stop();
+          }
 
-        ctx.log('Updating server...');
-        let ok = false;
-        try {
-          steamcmdDownloadGame({
-            steambeta: omegga.config.server?.steambeta,
-            steambetaPassword: omegga.config.server?.steambetaPassword,
-          });
-          ok = true;
-          ctx.log('Server updated successfully');
-        } catch (err) {
-          ctx.error('Error updating server', err);
-        }
+          ctx.log('Updating server...');
+          let ok = false;
+          try {
+            steamcmdDownloadGame({
+              steambeta: omegga.config.server?.steambeta,
+              steambetaPassword: omegga.config.server?.steambetaPassword,
+            });
+            ok = true;
+            ctx.log('Server updated successfully');
+          } catch (err) {
+            ctx.error('Error updating server', err);
+          }
 
-        if (wasStarted) {
-          ctx.log('Starting server...');
-          await omegga.start();
-        }
+          if (wasStarted) {
+            ctx.log('Starting server...');
+            await omegga.start();
+          }
 
-        return ok;
-      }),
+          return ok;
+        },
+      ),
     }),
 
-    onStatus: protectedProcedure('server.onStatus').subscription(
+    onStatus: protectedProcedure(ScopeName.ServerStatus).subscription(
       async function* ({ signal }) {
         for await (const [_] of on(serverEvents, 'serverStatus', { signal })) {
           const { omegga } = getContextDeps();
@@ -190,7 +199,7 @@ export const serverRouter = router({
       },
     ),
 
-    onHeartbeat: protectedProcedure('server.onHeartbeat').subscription(
+    onHeartbeat: protectedProcedure(ScopeName.ServerStatus).subscription(
       async function* ({ signal }) {
         for await (const [status] of on(serverEvents, 'heartbeat', {
           signal,
@@ -200,7 +209,7 @@ export const serverRouter = router({
       },
     ),
 
-    onUtilization: protectedProcedure('server.onUtilization').subscription(
+    onUtilization: protectedProcedure(ScopeName.ServerUtilization).subscription(
       async function* ({ signal }) {
         for await (const [utilization] of on(serverEvents, 'utilization', {
           signal,

--- a/src/webserver/backend/router/server.ts
+++ b/src/webserver/backend/router/server.ts
@@ -187,8 +187,11 @@ export const serverRouter = router({
     }),
 
     onStatus: protectedProcedure(ScopeName.ServerStatus).subscription(
-      async function* ({ signal }) {
-        for await (const [_] of on(serverEvents, 'serverStatus', { signal })) {
+      async function* ({ signal, ctx }) {
+        const combined = AbortSignal.any([signal!, ctx.userAbort.signal]);
+        for await (const [_] of on(serverEvents, 'serverStatus', {
+          signal: combined,
+        })) {
           const { omegga } = getContextDeps();
           yield {
             started: omegga.started,
@@ -200,9 +203,10 @@ export const serverRouter = router({
     ),
 
     onHeartbeat: protectedProcedure(ScopeName.ServerStatus).subscription(
-      async function* ({ signal }) {
+      async function* ({ signal, ctx }) {
+        const combined = AbortSignal.any([signal!, ctx.userAbort.signal]);
         for await (const [status] of on(serverEvents, 'heartbeat', {
-          signal,
+          signal: combined,
         })) {
           yield status;
         }
@@ -210,9 +214,10 @@ export const serverRouter = router({
     ),
 
     onUtilization: protectedProcedure(ScopeName.ServerUtilization).subscription(
-      async function* ({ signal }) {
+      async function* ({ signal, ctx }) {
+        const combined = AbortSignal.any([signal!, ctx.userAbort.signal]);
         for await (const [utilization] of on(serverEvents, 'utilization', {
-          signal,
+          signal: combined,
         })) {
           yield utilization as import('../types').SystemUtilization;
         }

--- a/src/webserver/backend/router/session.ts
+++ b/src/webserver/backend/router/session.ts
@@ -1,12 +1,16 @@
 import { getLastSteamUpdateCheck } from '@/updater/steam';
 import { VERSION } from '@/version';
+import { EMPTY_PERMISSIONS, RootLevel, resolveAllScopes } from '../permissions';
+import { ScopeName } from '../scopes';
 import { router, protectedProcedure, getContextDeps } from '../trpc';
 
 export const sessionRouter = router({
   session: router({
-    info: protectedProcedure('session.info').query(async ({ ctx }) => {
+    info: protectedProcedure(ScopeName.SessionInfo).query(async ({ ctx }) => {
       const { database, omegga } = getContextDeps();
       const roles = await database.getRoles();
+      const defaults = await database.getDefaultPermissions();
+      const userPerms = ctx.user.permissions ?? EMPTY_PERMISSIONS;
 
       return {
         roles,
@@ -19,6 +23,13 @@ export const sessionRouter = router({
           username: ctx.user.username || 'Admin',
           isOwner: ctx.user.isOwner,
           roles: ctx.user.roles,
+          permissions: userPerms,
+          resolvedScopes: ctx.user.isOwner
+            ? resolveAllScopes(
+                { root: RootLevel.All, domains: {}, scopes: {} },
+                null,
+              )
+            : resolveAllScopes(userPerms, defaults),
         },
         isSteam: Boolean(omegga.config.__STEAM),
         update: {

--- a/src/webserver/backend/router/user.ts
+++ b/src/webserver/backend/router/user.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v4';
 import {
+  decodePermissions,
   resolveAllScopes,
   userHasScope,
   type PermissionSet,
@@ -33,12 +34,24 @@ export const userRouter = router({
         const { page, search, sort, direction } = input;
         const resp = await database.getUsers({ page, search, sort, direction });
         const now = Date.now();
-        resp.users = resp.users.map(({ hash: _, ...user }) => ({
-          ...user,
-          hash: '',
-          seenAgo: user.lastOnline ? now - user.lastOnline : Infinity,
-          createdAgo: now - user.created,
-        }));
+        resp.users = resp.users.map(
+          ({
+            hash: _h,
+            totpSecret: _ts,
+            recoveryCodes: _rc,
+            passkeys: _pk,
+            permissions: _perms,
+            ...user
+          }) => ({
+            ...user,
+            hash: '',
+            permissions: decodePermissions(_perms as any),
+            totpEnabled: user.totpEnabled ?? false,
+            passkeyCount: _pk?.length ?? 0,
+            seenAgo: user.lastOnline ? now - user.lastOnline : Infinity,
+            createdAgo: now - user.created,
+          }),
+        );
         return resp;
       }),
 
@@ -53,6 +66,8 @@ export const userRouter = router({
         seenAgo: ctx.user.lastOnline ? now - ctx.user.lastOnline : Infinity,
         createdAgo: now - (ctx.user.created ?? now),
         permissions: ctx.user.permissions,
+        totpEnabled: ctx.user.totpEnabled ?? false,
+        passkeyCount: ctx.user.passkeys?.length ?? 0,
       };
     }),
 
@@ -107,6 +122,7 @@ export const userRouter = router({
         z.object({
           username: z.string(),
           password: z.string(),
+          currentPassword: z.string().optional(),
         }),
       )
       .mutation(async ({ input, ctx }) => {
@@ -115,7 +131,12 @@ export const userRouter = router({
         const { log, error } = ctx;
 
         const isSelf = username === ctx.user.username;
-        if (!isSelf) {
+        if (isSelf) {
+          if (!input.currentPassword) return 'current password required';
+          const bcryptLib = await import('bcryptjs');
+          if (!(await bcryptLib.compare(input.currentPassword, ctx.user.hash)))
+            return 'incorrect current password';
+        } else {
           const defaults = await database.getDefaultPermissions();
           if (!userHasScope(ctx.user, ScopeName.UserPasswd, defaults))
             return 'missing permission';
@@ -159,9 +180,7 @@ export const userRouter = router({
         if (target?.isOwner) return 'cannot disable the owner';
 
         await database.banUser(username, banned);
-        log(
-          `${banned ? 'disabled' : 'enabled'} user "${username.yellow}" (by ${ctx.user.username.yellow})`,
-        );
+        log(`${banned ? 'disabled' : 'enabled'} user "${username.yellow}"`);
         return '';
       }),
 
@@ -186,9 +205,7 @@ export const userRouter = router({
         if (target?.isOwner) return 'cannot delete the owner';
 
         await database.deleteUser(username);
-        log(
-          `deleted user "${username.yellow}" (by ${ctx.user.username.yellow})`,
-        );
+        log(`deleted user "${username.yellow}"`);
         return '';
       }),
 
@@ -226,9 +243,7 @@ export const userRouter = router({
         }
 
         await database.setUserPermissions(username, permissions);
-        log(
-          `updated permissions for "${username.yellow}" (by ${ctx.user.username.yellow})`,
-        );
+        log(`updated permissions for "${username.yellow}"`);
         return '';
       }),
 
@@ -251,9 +266,29 @@ export const userRouter = router({
           await database.setDefaultPermissions(
             input as unknown as PermissionSet,
           );
-          log(`updated default permissions (by ${ctx.user.username.yellow})`);
+          log(`updated default permissions`);
           return '';
         }),
     }),
+
+    resetMfa: protectedProcedure(ScopeName.UserResetMfa)
+      .input(z.object({ username: z.string() }))
+      .mutation(async ({ input, ctx }) => {
+        const { database } = getContextDeps();
+        const { username } = input;
+        const { log } = ctx;
+
+        if (username === ctx.user.username) return 'cannot reset own MFA';
+
+        const target = await database.stores.users.findOne<
+          IStoreUser & { _id: string }
+        >({ type: 'user', username });
+        if (!target) return 'user does not exist';
+        if (target.isOwner) return 'cannot reset the owner';
+
+        await database.resetUserMfa(username);
+        log(`reset MFA for "${username.yellow}"`);
+        return '';
+      }),
   }),
 });

--- a/src/webserver/backend/router/user.ts
+++ b/src/webserver/backend/router/user.ts
@@ -103,5 +103,60 @@ export const userRouter = router({
         log(`changed password for "${username.yellow}"`);
         return '';
       }),
+
+    ban: protectedProcedure('user.ban')
+      .input(
+        z.object({
+          username: z.string(),
+          banned: z.boolean(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const { database } = getContextDeps();
+        const { username, banned } = input;
+        const { log } = ctx;
+
+        if (!ctx.user.isOwner) return 'missing permission';
+        if (username === ctx.user.username) return 'cannot disable yourself';
+        if (!(await database.userExists(username)))
+          return 'user does not exist';
+
+        const target = await database.stores.users.findOne<
+          import('../types').IStoreUser & { _id: string }
+        >({ type: 'user', username });
+        if (target?.isOwner) return 'cannot disable the owner';
+
+        await database.banUser(username, banned);
+        log(
+          `${banned ? 'disabled' : 'enabled'} user "${username.yellow}" (by ${ctx.user.username.yellow})`,
+        );
+        return '';
+      }),
+
+    delete: protectedProcedure('user.delete')
+      .input(
+        z.object({
+          username: z.string(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const { database } = getContextDeps();
+        const { username } = input;
+        const { log } = ctx;
+
+        if (!ctx.user.isOwner) return 'missing permission';
+        if (username === ctx.user.username) return 'cannot delete yourself';
+        if (!(await database.userExists(username)))
+          return 'user does not exist';
+
+        const target = await database.stores.users.findOne<
+          import('../types').IStoreUser & { _id: string }
+        >({ type: 'user', username });
+        if (target?.isOwner) return 'cannot delete the owner';
+
+        await database.deleteUser(username);
+        log(`deleted user "${username.yellow}" (by ${ctx.user.username.yellow})`);
+        return '';
+      }),
   }),
 });

--- a/src/webserver/backend/router/user.ts
+++ b/src/webserver/backend/router/user.ts
@@ -1,9 +1,22 @@
 import { z } from 'zod/v4';
+import {
+  resolveAllScopes,
+  userHasScope,
+  type PermissionSet,
+} from '../permissions';
+import { ScopeName } from '../scopes';
 import { router, protectedProcedure, getContextDeps } from '../trpc';
+import type { IStoreUser } from '../types';
+
+const PermissionSetSchema = z.object({
+  root: z.enum(['all', 'read', 'off']),
+  domains: z.record(z.string(), z.enum(['all', 'read', 'none'])),
+  scopes: z.record(z.string(), z.boolean()),
+});
 
 export const userRouter = router({
   user: router({
-    list: protectedProcedure('user.list')
+    list: protectedProcedure(ScopeName.UserList)
       .input(
         z
           .object({
@@ -29,7 +42,21 @@ export const userRouter = router({
         return resp;
       }),
 
-    create: protectedProcedure('user.create')
+    self: protectedProcedure(ScopeName.SessionInfo).query(async ({ ctx }) => {
+      const now = Date.now();
+      return {
+        username: ctx.user.username || 'Admin',
+        isOwner: ctx.user.isOwner,
+        isBanned: ctx.user.isBanned ?? false,
+        lastOnline: ctx.user.lastOnline ?? 0,
+        created: ctx.user.created ?? 0,
+        seenAgo: ctx.user.lastOnline ? now - ctx.user.lastOnline : Infinity,
+        createdAgo: now - (ctx.user.created ?? now),
+        permissions: ctx.user.permissions,
+      };
+    }),
+
+    create: protectedProcedure(ScopeName.UserCreate)
       .input(
         z.object({
           username: z.string(),
@@ -41,7 +68,6 @@ export const userRouter = router({
         const { username, password } = input;
         const { log, error } = ctx;
 
-        if (!ctx.user.isOwner) return 'missing permission';
         if (typeof username !== 'string' || typeof password !== 'string')
           return 'username/password not a string';
         if (!username.match(/^\w{0,32}$/)) return 'username is not allowed';
@@ -74,7 +100,9 @@ export const userRouter = router({
         return '';
       }),
 
-    passwd: protectedProcedure('user.passwd')
+    // self-service: any authenticated user can change their own password
+    // changing another user's password requires user.passwd permission (enforced here)
+    passwd: protectedProcedure(ScopeName.SessionInfo)
       .input(
         z.object({
           username: z.string(),
@@ -86,8 +114,13 @@ export const userRouter = router({
         const { username, password } = input;
         const { log, error } = ctx;
 
-        if (!ctx.user.isOwner && username !== ctx.user.username)
-          return 'missing permission';
+        const isSelf = username === ctx.user.username;
+        if (!isSelf) {
+          const defaults = await database.getDefaultPermissions();
+          if (!userHasScope(ctx.user, ScopeName.UserPasswd, defaults))
+            return 'missing permission';
+        }
+
         if (typeof username !== 'string' || typeof password !== 'string')
           return 'username/password not a string';
         if (!username.match(/^\w{0,32}$/)) return 'username is not allowed';
@@ -104,7 +137,7 @@ export const userRouter = router({
         return '';
       }),
 
-    ban: protectedProcedure('user.ban')
+    ban: protectedProcedure(ScopeName.UserBan)
       .input(
         z.object({
           username: z.string(),
@@ -116,13 +149,12 @@ export const userRouter = router({
         const { username, banned } = input;
         const { log } = ctx;
 
-        if (!ctx.user.isOwner) return 'missing permission';
         if (username === ctx.user.username) return 'cannot disable yourself';
         if (!(await database.userExists(username)))
           return 'user does not exist';
 
         const target = await database.stores.users.findOne<
-          import('../types').IStoreUser & { _id: string }
+          IStoreUser & { _id: string }
         >({ type: 'user', username });
         if (target?.isOwner) return 'cannot disable the owner';
 
@@ -133,7 +165,7 @@ export const userRouter = router({
         return '';
       }),
 
-    delete: protectedProcedure('user.delete')
+    delete: protectedProcedure(ScopeName.UserDelete)
       .input(
         z.object({
           username: z.string(),
@@ -144,19 +176,84 @@ export const userRouter = router({
         const { username } = input;
         const { log } = ctx;
 
-        if (!ctx.user.isOwner) return 'missing permission';
         if (username === ctx.user.username) return 'cannot delete yourself';
         if (!(await database.userExists(username)))
           return 'user does not exist';
 
         const target = await database.stores.users.findOne<
-          import('../types').IStoreUser & { _id: string }
+          IStoreUser & { _id: string }
         >({ type: 'user', username });
         if (target?.isOwner) return 'cannot delete the owner';
 
         await database.deleteUser(username);
-        log(`deleted user "${username.yellow}" (by ${ctx.user.username.yellow})`);
+        log(
+          `deleted user "${username.yellow}" (by ${ctx.user.username.yellow})`,
+        );
         return '';
       }),
+
+    permissions: protectedProcedure(ScopeName.UserPermissions)
+      .input(
+        z.object({
+          username: z.string(),
+          permissions: PermissionSetSchema,
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const { database } = getContextDeps();
+        const { username } = input;
+        const permissions = input.permissions as PermissionSet;
+        const { log } = ctx;
+
+        if (username === ctx.user.username)
+          return 'cannot edit own permissions';
+
+        const target = await database.stores.users.findOne<
+          IStoreUser & { _id: string }
+        >({ type: 'user', username });
+        if (!target) return 'user does not exist';
+        if (target.isOwner) return 'cannot edit the owner';
+
+        // privilege escalation check: non-owner can't grant scopes they don't have
+        if (!ctx.user.isOwner) {
+          const defaults = await database.getDefaultPermissions();
+          const myScopes = resolveAllScopes(ctx.user.permissions!, defaults);
+          const grantedScopes = resolveAllScopes(permissions, defaults);
+          for (const [scope, granted] of Object.entries(grantedScopes)) {
+            if (granted && !myScopes[scope as keyof typeof myScopes])
+              return `cannot grant permission you do not have: ${scope}`;
+          }
+        }
+
+        await database.setUserPermissions(username, permissions);
+        log(
+          `updated permissions for "${username.yellow}" (by ${ctx.user.username.yellow})`,
+        );
+        return '';
+      }),
+
+    defaultPermissions: router({
+      get: protectedProcedure(ScopeName.UserPermissions).query(async () => {
+        const { database } = getContextDeps();
+        const defaults = await database.getDefaultPermissions();
+        return {
+          root: defaults.root,
+          domains: defaults.domains,
+          scopes: defaults.scopes,
+        };
+      }),
+
+      set: protectedProcedure(ScopeName.UserPermissions)
+        .input(PermissionSetSchema)
+        .mutation(async ({ input, ctx }) => {
+          const { database } = getContextDeps();
+          const { log } = ctx;
+          await database.setDefaultPermissions(
+            input as unknown as PermissionSet,
+          );
+          log(`updated default permissions (by ${ctx.user.username.yellow})`);
+          return '';
+        }),
+    }),
   }),
 });

--- a/src/webserver/backend/router/world.ts
+++ b/src/webserver/backend/router/world.ts
@@ -1,10 +1,11 @@
 import { readBrdbMeta } from '@util/brdb';
 import { z } from 'zod/v4';
+import { ScopeName } from '../scopes';
 import { getContextDeps, protectedProcedure, router } from '../trpc';
 
 export const worldRouter = router({
   world: router({
-    list: protectedProcedure('world.list').query(() => {
+    list: protectedProcedure(ScopeName.WorldList).query(() => {
       const { omegga } = getContextDeps();
       const prefix = omegga.worldPath + '/';
       return omegga
@@ -12,7 +13,7 @@ export const worldRouter = router({
         .map(world => world.replace(prefix, '').replace(/\.brdb$/, ''));
     }),
 
-    revisions: protectedProcedure('world.revisions')
+    revisions: protectedProcedure(ScopeName.WorldRevisions)
       .input(z.object({ world: z.string() }))
       .query(async ({ input }) => {
         const { omegga } = getContextDeps();
@@ -27,7 +28,7 @@ export const worldRouter = router({
         }
       }),
 
-    meta: protectedProcedure('world.meta')
+    meta: protectedProcedure(ScopeName.WorldMeta)
       .input(z.object({ world: z.string() }))
       .query(async ({ input, ctx }) => {
         const { omegga } = getContextDeps();
@@ -41,17 +42,17 @@ export const worldRouter = router({
         }
       }),
 
-    next: protectedProcedure('world.next').query(() => {
+    next: protectedProcedure(ScopeName.WorldNext).query(() => {
       const { omegga } = getContextDeps();
       return omegga.getNextWorld();
     }),
 
-    active: protectedProcedure('world.active').query(() => {
+    active: protectedProcedure(ScopeName.WorldActive).query(() => {
       const { omegga } = getContextDeps();
       return omegga.getActiveWorld();
     }),
 
-    load: protectedProcedure('world.load')
+    load: protectedProcedure(ScopeName.WorldLoad)
       .input(
         z.object({
           world: z.string(),
@@ -84,7 +85,7 @@ export const worldRouter = router({
         }
       }),
 
-    use: protectedProcedure('world.use')
+    use: protectedProcedure(ScopeName.WorldUse)
       .input(
         z.object({
           world: z.string().optional(),
@@ -103,7 +104,7 @@ export const worldRouter = router({
         }
       }),
 
-    create: protectedProcedure('world.create')
+    create: protectedProcedure(ScopeName.WorldCreate)
       .input(
         z.object({
           name: z.string(),
@@ -130,7 +131,7 @@ export const worldRouter = router({
         }
       }),
 
-    save: protectedProcedure('world.save')
+    save: protectedProcedure(ScopeName.WorldSave)
       .input(
         z
           .object({

--- a/src/webserver/backend/scopes.ts
+++ b/src/webserver/backend/scopes.ts
@@ -43,6 +43,8 @@ export const SCOPES = {
   'user.list': { description: 'View web UI users' },
   'user.create': { description: 'Create web UI users' },
   'user.passwd': { description: 'Change user passwords' },
+  'user.ban': { description: 'Disable/enable web UI users' },
+  'user.delete': { description: 'Delete web UI users' },
 
   // World
   'world.list': { description: 'View world list' },

--- a/src/webserver/backend/scopes.ts
+++ b/src/webserver/backend/scopes.ts
@@ -46,6 +46,8 @@ export const ScopeName = {
   UserBan: 'user.ban',
   UserDelete: 'user.delete',
   UserPermissions: 'user.permissions',
+  UserReadMfa: 'user.readMfa',
+  UserResetMfa: 'user.resetMfa',
 
   WorldList: 'world.list',
   WorldActive: 'world.active',
@@ -232,6 +234,16 @@ export const SCOPES = {
   },
   [S.UserPermissions]: {
     description: 'Manage user permissions',
+    readOnly: false,
+    domain: D.User,
+  },
+  [S.UserReadMfa]: {
+    description: 'View MFA status of other users',
+    readOnly: true,
+    domain: D.User,
+  },
+  [S.UserResetMfa]: {
+    description: 'Reset MFA for other users',
     readOnly: false,
     domain: D.User,
   },

--- a/src/webserver/backend/scopes.ts
+++ b/src/webserver/backend/scopes.ts
@@ -1,67 +1,307 @@
+export const ScopeDomain = {
+  Chat: 'chat',
+  Player: 'player',
+  Plugin: 'plugin',
+  Server: 'server',
+  User: 'user',
+  World: 'world',
+  Role: 'role',
+  Session: 'session',
+} as const;
+
+export const ScopeName = {
+  ChatSend: 'chat.send',
+  ChatRecent: 'chat.recent',
+  ChatHistory: 'chat.history',
+  ChatCalendar: 'chat.calendar',
+
+  PlayerList: 'player.list',
+  PlayerGet: 'player.get',
+  PlayerBan: 'player.ban',
+  PlayerKick: 'player.kick',
+  PlayerUnban: 'player.unban',
+  PlayerClearBricks: 'player.clearBricks',
+
+  PluginList: 'plugin.list',
+  PluginGet: 'plugin.get',
+  PluginConfig: 'plugin.config',
+  PluginLoad: 'plugin.load',
+  PluginUnload: 'plugin.unload',
+  PluginToggle: 'plugin.toggle',
+  PluginReloadAll: 'plugin.reloadAll',
+
+  ServerStatus: 'server.status',
+  ServerStart: 'server.start',
+  ServerStop: 'server.stop',
+  ServerRestart: 'server.restart',
+  ServerUpdateCheck: 'server.update.check',
+  ServerUpdateRun: 'server.update.run',
+  ServerAutorestartGet: 'server.autorestart.get',
+  ServerAutorestartSet: 'server.autorestart.set',
+  ServerUtilization: 'server.utilization',
+
+  UserList: 'user.list',
+  UserCreate: 'user.create',
+  UserPasswd: 'user.passwd',
+  UserBan: 'user.ban',
+  UserDelete: 'user.delete',
+  UserPermissions: 'user.permissions',
+
+  WorldList: 'world.list',
+  WorldActive: 'world.active',
+  WorldNext: 'world.next',
+  WorldRevisions: 'world.revisions',
+  WorldMeta: 'world.meta',
+  WorldLoad: 'world.load',
+  WorldUse: 'world.use',
+  WorldSave: 'world.save',
+  WorldCreate: 'world.create',
+
+  RoleList: 'role.list',
+
+  SessionInfo: 'session.info',
+} as const;
+
+const S = ScopeName;
+const D = ScopeDomain;
+
 export const SCOPES = {
   // Chat
-  'chat.send': { description: 'Send chat messages' },
-  'chat.recent': { description: 'View recent chat messages' },
-  'chat.history': { description: 'View chat history' },
-  'chat.calendar': { description: 'View chat calendar' },
-  'chat.onMessage': { description: 'Receive live chat messages' },
+  [S.ChatSend]: {
+    description: 'Send chat messages',
+    readOnly: false,
+    domain: D.Chat,
+  },
+  [S.ChatRecent]: {
+    description: 'View recent chat messages',
+    readOnly: true,
+    domain: D.Chat,
+  },
+  [S.ChatHistory]: {
+    description: 'View chat history',
+    readOnly: true,
+    domain: D.Chat,
+  },
+  [S.ChatCalendar]: {
+    description: 'View chat calendar',
+    readOnly: true,
+    domain: D.Chat,
+  },
 
   // Player
-  'player.list': { description: 'View player list' },
-  'player.get': { description: 'View player details' },
-  'player.ban': { description: 'Ban players' },
-  'player.kick': { description: 'Kick players' },
-  'player.unban': { description: 'Unban players' },
-  'player.clearBricks': { description: 'Clear player bricks' },
+  [S.PlayerList]: {
+    description: 'View player list',
+    readOnly: true,
+    domain: D.Player,
+  },
+  [S.PlayerGet]: {
+    description: 'View player details',
+    readOnly: true,
+    domain: D.Player,
+  },
+  [S.PlayerBan]: {
+    description: 'Ban players',
+    readOnly: false,
+    domain: D.Player,
+  },
+  [S.PlayerKick]: {
+    description: 'Kick players',
+    readOnly: false,
+    domain: D.Player,
+  },
+  [S.PlayerUnban]: {
+    description: 'Unban players',
+    readOnly: false,
+    domain: D.Player,
+  },
+  [S.PlayerClearBricks]: {
+    description: 'Clear player bricks',
+    readOnly: false,
+    domain: D.Player,
+  },
 
   // Plugin
-  'plugin.list': { description: 'View plugin list' },
-  'plugin.get': { description: 'View plugin details' },
-  'plugin.config': { description: 'Change plugin configuration' },
-  'plugin.load': { description: 'Load plugins' },
-  'plugin.unload': { description: 'Unload plugins' },
-  'plugin.toggle': { description: 'Enable/disable plugins' },
-  'plugin.reloadAll': { description: 'Reload all plugins' },
-  'plugin.onStatus': { description: 'Receive plugin status updates' },
+  [S.PluginList]: {
+    description: 'View plugin list',
+    readOnly: true,
+    domain: D.Plugin,
+  },
+  [S.PluginGet]: {
+    description: 'View plugin details',
+    readOnly: true,
+    domain: D.Plugin,
+  },
+  [S.PluginConfig]: {
+    description: 'Change plugin configuration',
+    readOnly: false,
+    domain: D.Plugin,
+  },
+  [S.PluginLoad]: {
+    description: 'Load plugins',
+    readOnly: false,
+    domain: D.Plugin,
+  },
+  [S.PluginUnload]: {
+    description: 'Unload plugins',
+    readOnly: false,
+    domain: D.Plugin,
+  },
+  [S.PluginToggle]: {
+    description: 'Enable/disable plugins',
+    readOnly: false,
+    domain: D.Plugin,
+  },
+  [S.PluginReloadAll]: {
+    description: 'Reload all plugins',
+    readOnly: false,
+    domain: D.Plugin,
+  },
 
   // Server
-  'server.status': { description: 'View server status' },
-  'server.started': { description: 'View server run state' },
-  'server.start': { description: 'Start the server' },
-  'server.stop': { description: 'Stop the server' },
-  'server.restart': { description: 'Restart the server' },
-  'server.update.check': { description: 'Check for server updates' },
-  'server.update.run': { description: 'Update the server' },
-  'server.autorestart.get': { description: 'View auto-restart config' },
-  'server.autorestart.set': { description: 'Change auto-restart config' },
-  'server.onStatus': { description: 'Receive server status updates' },
-  'server.onHeartbeat': { description: 'Receive server heartbeat' },
-  'server.utilization': { description: 'View current system utilization' },
-  'server.onUtilization': { description: 'Receive system utilization metrics' },
+  [S.ServerStatus]: {
+    description: 'View server status',
+    readOnly: true,
+    domain: D.Server,
+  },
+  [S.ServerStart]: {
+    description: 'Start the server',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerStop]: {
+    description: 'Stop the server',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerRestart]: {
+    description: 'Restart the server',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerUpdateCheck]: {
+    description: 'Check for server updates',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerUpdateRun]: {
+    description: 'Update the server',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerAutorestartGet]: {
+    description: 'View auto-restart config',
+    readOnly: true,
+    domain: D.Server,
+  },
+  [S.ServerAutorestartSet]: {
+    description: 'Change auto-restart config',
+    readOnly: false,
+    domain: D.Server,
+  },
+  [S.ServerUtilization]: {
+    description: 'View current system utilization',
+    readOnly: true,
+    domain: D.Server,
+  },
 
   // User
-  'user.list': { description: 'View web UI users' },
-  'user.create': { description: 'Create web UI users' },
-  'user.passwd': { description: 'Change user passwords' },
-  'user.ban': { description: 'Disable/enable web UI users' },
-  'user.delete': { description: 'Delete web UI users' },
+  [S.UserList]: {
+    description: 'View web UI users',
+    readOnly: true,
+    domain: D.User,
+  },
+  [S.UserCreate]: {
+    description: 'Create web UI users',
+    readOnly: false,
+    domain: D.User,
+  },
+  [S.UserPasswd]: {
+    description: 'Change user passwords',
+    readOnly: false,
+    domain: D.User,
+  },
+  [S.UserBan]: {
+    description: 'Disable/enable web UI users',
+    readOnly: false,
+    domain: D.User,
+  },
+  [S.UserDelete]: {
+    description: 'Delete web UI users',
+    readOnly: false,
+    domain: D.User,
+  },
+  [S.UserPermissions]: {
+    description: 'Manage user permissions',
+    readOnly: false,
+    domain: D.User,
+  },
 
   // World
-  'world.list': { description: 'View world list' },
-  'world.active': { description: 'View active world' },
-  'world.next': { description: 'View next world' },
-  'world.revisions': { description: 'View world revisions' },
-  'world.meta': { description: 'View world metadata' },
-  'world.load': { description: 'Load worlds' },
-  'world.use': { description: 'Set default world' },
-  'world.save': { description: 'Save worlds' },
-  'world.create': { description: 'Create worlds' },
+  [S.WorldList]: {
+    description: 'View world list',
+    readOnly: true,
+    domain: D.World,
+  },
+  [S.WorldActive]: {
+    description: 'View active world',
+    readOnly: true,
+    domain: D.World,
+  },
+  [S.WorldNext]: {
+    description: 'View next world',
+    readOnly: true,
+    domain: D.World,
+  },
+  [S.WorldRevisions]: {
+    description: 'View world revisions',
+    readOnly: true,
+    domain: D.World,
+  },
+  [S.WorldMeta]: {
+    description: 'View world metadata',
+    readOnly: true,
+    domain: D.World,
+  },
+  [S.WorldLoad]: {
+    description: 'Load worlds',
+    readOnly: false,
+    domain: D.World,
+  },
+  [S.WorldUse]: {
+    description: 'Set default world',
+    readOnly: false,
+    domain: D.World,
+  },
+  [S.WorldSave]: {
+    description: 'Save worlds',
+    readOnly: false,
+    domain: D.World,
+  },
+  [S.WorldCreate]: {
+    description: 'Create worlds',
+    readOnly: false,
+    domain: D.World,
+  },
 
   // Role
-  'role.list': { description: 'View server roles' },
+  [S.RoleList]: {
+    description: 'View server roles',
+    readOnly: true,
+    domain: D.Role,
+  },
 
   // Session
-  'session.info': { description: 'View session info' },
+  [S.SessionInfo]: {
+    description: 'View session info',
+    readOnly: true,
+    domain: D.Session,
+  },
 } as const;
 
 export type Scope = keyof typeof SCOPES;
+
+export const DOMAINS = [
+  ...new Set(Object.values(SCOPES).map(s => s.domain)),
+] as const;
+
+export type Domain = (typeof DOMAINS)[number];

--- a/src/webserver/backend/totp.test.ts
+++ b/src/webserver/backend/totp.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { TOTP, Secret } from 'otpauth';
+import {
+  generateSecret,
+  generateToken,
+  verifyToken,
+  generateURI,
+} from './totp';
+
+describe('TOTP', () => {
+  // RFC 6238 Appendix B test vectors
+  // The test secret is ASCII "12345678901234567890" (20 bytes for SHA1)
+  const RFC_SECRET_RAW = Buffer.from('12345678901234567890', 'ascii');
+  const RFC_SECRET = new Secret({ buffer: RFC_SECRET_RAW });
+  const RFC_SECRET_B32 = RFC_SECRET.base32;
+
+  // RFC 6238 test vectors for SHA1, 8-digit TOTP
+  // We verify the underlying otpauth library produces correct results
+  const RFC_VECTORS_8DIGIT: [number, string][] = [
+    [59, '94287082'],
+    [1111111109, '07081804'],
+    [1111111111, '14050471'],
+    [1234567890, '89005924'],
+    [2000000000, '69279037'],
+    [20000000000, '65353130'],
+  ];
+
+  describe('RFC 6238 compliance (8-digit, raw library)', () => {
+    for (const [time, expected] of RFC_VECTORS_8DIGIT) {
+      it(`generates correct OTP at time=${time}`, () => {
+        const totp = new TOTP({
+          secret: RFC_SECRET,
+          digits: 8,
+          period: 30,
+          algorithm: 'SHA1',
+        });
+        const token = totp.generate({ timestamp: time * 1000 });
+        expect(token).toBe(expected);
+      });
+    }
+  });
+
+  // Our wrapper uses 6 digits (standard for authenticator apps).
+  // Verify it produces the truncated-to-6 versions of the RFC vectors.
+  const RFC_VECTORS_6DIGIT: [number, string][] = RFC_VECTORS_8DIGIT.map(
+    ([time, code]) => [time, code.slice(-6)],
+  );
+
+  describe('RFC 6238 compliance (6-digit, our wrapper)', () => {
+    for (const [time, expected] of RFC_VECTORS_6DIGIT) {
+      it(`generates correct 6-digit OTP at time=${time}`, () => {
+        const totp = new TOTP({
+          secret: Secret.fromBase32(RFC_SECRET_B32),
+          digits: 6,
+          period: 30,
+          algorithm: 'SHA1',
+        });
+        const token = totp.generate({ timestamp: time * 1000 });
+        expect(token).toBe(expected);
+      });
+    }
+  });
+
+  describe('generateSecret', () => {
+    it('generates a valid base32 string', () => {
+      const secret = generateSecret();
+      expect(secret).toMatch(/^[A-Z2-7]+$/);
+      expect(secret.length).toBeGreaterThanOrEqual(20);
+    });
+
+    it('generates unique secrets', () => {
+      const secrets = new Set(Array.from({ length: 10 }, generateSecret));
+      expect(secrets.size).toBe(10);
+    });
+
+    it('round-trips through Secret.fromBase32', () => {
+      const secret = generateSecret();
+      expect(() => Secret.fromBase32(secret)).not.toThrow();
+    });
+  });
+
+  describe('generateToken', () => {
+    it('generates a 6-digit string', () => {
+      const secret = generateSecret();
+      const token = generateToken(secret);
+      expect(token).toMatch(/^\d{6}$/);
+    });
+
+    it('generates the same token for the same secret within a time step', () => {
+      const secret = generateSecret();
+      const a = generateToken(secret);
+      const b = generateToken(secret);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('accepts a valid current token', () => {
+      const secret = generateSecret();
+      const token = generateToken(secret);
+      expect(verifyToken(token, secret)).toBe(true);
+    });
+
+    it('rejects an invalid token', () => {
+      const secret = generateSecret();
+      expect(verifyToken('000000', secret)).toBe(false);
+    });
+
+    it('rejects malformed tokens', () => {
+      const secret = generateSecret();
+      expect(verifyToken('', secret)).toBe(false);
+      expect(verifyToken('12345', secret)).toBe(false);
+      expect(verifyToken('1234567', secret)).toBe(false);
+      expect(verifyToken('abcdef', secret)).toBe(false);
+      expect(verifyToken('12345a', secret)).toBe(false);
+    });
+
+    it('rejects tokens from a different secret', () => {
+      const secret1 = generateSecret();
+      const secret2 = generateSecret();
+      const token = generateToken(secret1);
+      expect(verifyToken(token, secret2)).toBe(false);
+    });
+
+    it('accepts tokens within the time window', () => {
+      const secret = generateSecret();
+      const totp = new TOTP({
+        secret: Secret.fromBase32(secret),
+        digits: 6,
+        period: 30,
+        algorithm: 'SHA1',
+      });
+      // Generate a token for the previous time step
+      const prevToken = totp.generate({
+        timestamp: Date.now() - 30 * 1000,
+      });
+      expect(verifyToken(prevToken, secret, 1)).toBe(true);
+    });
+
+    it('rejects tokens outside the time window', () => {
+      const secret = generateSecret();
+      const totp = new TOTP({
+        secret: Secret.fromBase32(secret),
+        digits: 6,
+        period: 30,
+        algorithm: 'SHA1',
+      });
+      // Generate a token 3 steps in the past
+      const oldToken = totp.generate({
+        timestamp: Date.now() - 90 * 1000,
+      });
+      expect(verifyToken(oldToken, secret, 1)).toBe(false);
+    });
+  });
+
+  describe('generateURI', () => {
+    it('generates a valid otpauth URI', () => {
+      const secret = generateSecret();
+      const uri = generateURI(secret, 'testuser');
+      expect(uri).toMatch(/^otpauth:\/\/totp\//);
+      expect(uri).toContain('secret=' + secret);
+      expect(uri).toContain('issuer=Omegga');
+      expect(uri).toContain('testuser');
+      expect(uri).toContain('digits=6');
+      expect(uri).toContain('period=30');
+    });
+
+    it('properly encodes special characters in username', () => {
+      const secret = generateSecret();
+      const uri = generateURI(secret, 'user@example.com');
+      expect(uri).toContain('user%40example.com');
+    });
+
+    it('contains all required parameters', () => {
+      const secret = generateSecret();
+      const uri = generateURI(secret, 'admin');
+      const url = new URL(uri);
+      expect(url.protocol).toBe('otpauth:');
+      expect(url.host).toBe('totp');
+      expect(url.searchParams.get('secret')).toBe(secret);
+      expect(url.searchParams.get('issuer')).toBe('Omegga');
+      expect(url.searchParams.get('digits')).toBe('6');
+      expect(url.searchParams.get('period')).toBe('30');
+    });
+  });
+});

--- a/src/webserver/backend/totp.ts
+++ b/src/webserver/backend/totp.ts
@@ -1,0 +1,39 @@
+import { TOTP, Secret } from 'otpauth';
+
+const ISSUER = 'Omegga';
+const DIGITS = 6;
+const PERIOD = 30;
+const ALGORITHM = 'SHA1';
+
+function makeTOTP(secret: string, label = ''): TOTP {
+  return new TOTP({
+    issuer: ISSUER,
+    label,
+    algorithm: ALGORITHM,
+    digits: DIGITS,
+    period: PERIOD,
+    secret: Secret.fromBase32(secret),
+  });
+}
+
+export function generateSecret(): string {
+  return new Secret().base32;
+}
+
+export function generateToken(secret: string): string {
+  return makeTOTP(secret).generate();
+}
+
+export function verifyToken(
+  token: string,
+  secret: string,
+  window = 1,
+): boolean {
+  if (!/^\d{6}$/.test(token)) return false;
+  const delta = makeTOTP(secret).validate({ token, window });
+  return delta !== null;
+}
+
+export function generateURI(secret: string, username: string): string {
+  return makeTOTP(secret, username).toString();
+}

--- a/src/webserver/backend/trpc.ts
+++ b/src/webserver/backend/trpc.ts
@@ -3,6 +3,7 @@ import type Omegga from '@omegga/server';
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
 import type Database from './database';
+import { userHasScope } from './permissions';
 import type { Scope } from './scopes';
 import type { IStoreUser } from './types';
 
@@ -62,10 +63,14 @@ export const publicProcedure = t.procedure;
 export const mergeRouters = t.mergeRouters;
 
 export const requireScope = (scope: Scope) =>
-  t.middleware(({ ctx, next }) => {
+  t.middleware(async ({ ctx, next }) => {
     if (!ctx.user) throw new TRPCError({ code: 'UNAUTHORIZED' });
-    // TODO: check ctx.user.roles against scope
-    // For now, all authenticated users pass
+    if (ctx.user.isOwner) return next({ ctx });
+    const { database } = getContextDeps();
+    const defaults = await database.getDefaultPermissions();
+    if (!userHasScope(ctx.user, scope, defaults)) {
+      throw new TRPCError({ code: 'FORBIDDEN' });
+    }
     return next({ ctx });
   });
 

--- a/src/webserver/backend/trpc.ts
+++ b/src/webserver/backend/trpc.ts
@@ -3,6 +3,7 @@ import type Omegga from '@omegga/server';
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
 import type Database from './database';
+import { serverEvents } from './events';
 import { userHasScope } from './permissions';
 import type { Scope } from './scopes';
 import type { IStoreUser } from './types';
@@ -26,6 +27,7 @@ export function getContextDeps(): ContextDeps {
 export type Context = {
   user: IStoreUser & { _id: string };
   req: import('express').Request;
+  userAbort: AbortController;
   log: (...args: any[]) => void;
   error: (...args: any[]) => void;
 };
@@ -54,9 +56,28 @@ export async function createContext(
 
   const usernameText = `[${(user.username || 'Admin').brightMagenta}]`;
 
+  let _userAbort: AbortController | null = null;
+  const getUserAbort = () => {
+    if (!_userAbort) {
+      _userAbort = new AbortController();
+      const ac = _userAbort;
+      const onInvalidated = (name: string) => {
+        if (name === user.username) ac.abort();
+      };
+      serverEvents.on('userInvalidated', onInvalidated);
+      ac.signal.addEventListener('abort', () => {
+        serverEvents.off('userInvalidated', onInvalidated);
+      });
+    }
+    return _userAbort;
+  };
+
   return {
     user,
     req,
+    get userAbort() {
+      return getUserAbort();
+    },
     log: (...args: any[]) => Logger.logp(usernameText, ...args),
     error: (...args: any[]) => Logger.errorp(usernameText, ...args),
   };

--- a/src/webserver/backend/trpc.ts
+++ b/src/webserver/backend/trpc.ts
@@ -25,6 +25,7 @@ export function getContextDeps(): ContextDeps {
 
 export type Context = {
   user: IStoreUser & { _id: string };
+  req: import('express').Request;
   log: (...args: any[]) => void;
   error: (...args: any[]) => void;
 };
@@ -35,7 +36,11 @@ export async function createContext(
   const { database } = getContextDeps();
   const req = opts.req;
 
-  const userId = (req as any).session?.userId;
+  const session = (req as any).session;
+  if (session?.mfaPending) {
+    throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+  const userId = session?.userId;
   const user = await database.findUserById(userId);
   if (!user || user.isBanned) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
@@ -51,12 +56,22 @@ export async function createContext(
 
   return {
     user,
+    req,
     log: (...args: any[]) => Logger.logp(usernameText, ...args),
     error: (...args: any[]) => Logger.errorp(usernameText, ...args),
   };
 }
 
-const t = initTRPC.context<Context>().create();
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error, path, ctx }) {
+    const user = (ctx as Context | undefined)?.user?.username || '?';
+    Logger.errorp(
+      `[${user.brightMagenta}]`,
+      `${error.code} ${path ?? '?'}: ${error.message}`,
+    );
+    return shape;
+  },
+});
 
 export const router = t.router;
 export const publicProcedure = t.procedure;
@@ -69,7 +84,10 @@ export const requireScope = (scope: Scope) =>
     const { database } = getContextDeps();
     const defaults = await database.getDefaultPermissions();
     if (!userHasScope(ctx.user, scope, defaults)) {
-      throw new TRPCError({ code: 'FORBIDDEN' });
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `missing scope: ${scope}`,
+      });
     }
     return next({ ctx });
   });

--- a/src/webserver/backend/types.d.ts
+++ b/src/webserver/backend/types.d.ts
@@ -1,7 +1,20 @@
 declare module 'express-session' {
   interface SessionData {
     userId: string;
+    mfaPending?: boolean;
+    mfaChallenge?: string;
+    pendingTotpSecret?: string;
   }
+}
+
+export interface IWebAuthnCredential {
+  id: string;
+  publicKey: string;
+  counter: number;
+  name: string;
+  created: number;
+  lastUsed: number;
+  transports?: string[];
 }
 
 export interface IPlayer {
@@ -118,6 +131,10 @@ export interface IStoreUser {
   playerId: string;
   isBanned?: boolean;
   permissions?: import('./permissions').PermissionSet;
+  totpSecret?: string;
+  totpEnabled?: boolean;
+  passkeys?: IWebAuthnCredential[];
+  recoveryCodes?: string[];
 }
 
 export interface IStoreDefaultPermissions {

--- a/src/webserver/backend/types.d.ts
+++ b/src/webserver/backend/types.d.ts
@@ -117,6 +117,16 @@ export interface IStoreUser {
   roles: string[];
   playerId: string;
   isBanned?: boolean;
+  permissions?: import('./permissions').PermissionSet;
+}
+
+export interface IStoreDefaultPermissions {
+  type: 'defaultPermissions';
+  root: import('./permissions').RootLevel;
+  domains: Partial<
+    Record<import('./scopes').Domain, import('./permissions').DomainLevel>
+  >;
+  scopes: Partial<Record<import('./scopes').Scope, boolean>>;
 }
 
 export interface IPunchcard {

--- a/vite.frontend.config.mts
+++ b/vite.frontend.config.mts
@@ -43,6 +43,9 @@ export default defineConfig({
   assetsInclude: ['**/*.webp'],
   build: {
     sourcemap: true,
+    watch: process.argv.includes('--watch')
+      ? { include: 'frontend/src/**' }
+      : null,
     rollupOptions: {
       input: {
         auth: resolve(__dirname, 'frontend/auth.html'),


### PR DESCRIPTION
## 1.6.0

- Add owner-only user disable and delete actions to the web UI
- Add granular permission system with scopes and domains for access control
- Add TOTP two-factor authentication, WebAuthn passkeys (passwordless), and recovery codes
- Add self-service account management (password change, MFA setup) for all users in the Account view
- Add `/user passwd` and `/user resetmfa` terminal commands
- Web UI: scope-aware enforcement -- buttons, views, queries, and subscriptions gated by user permissions
- Web UI: user inspector with permission editor, default permissions, user disable/delete
- Web UI: slightly improved responsive tablet layout for all views
- Deleted or banned users are immediately disconnected from active sessions and live subscriptions

<img width="990" height="750" alt="image" src="https://github.com/user-attachments/assets/89669f01-e305-4da1-b8c0-b344b7b4fc1a" />
<img width="1372" height="1034" alt="image" src="https://github.com/user-attachments/assets/9c0beded-8a17-41c8-b6c5-501305f77375" />
