### PR TITLE
1.8.0 - EA3 Preemptive Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Huge breaking changes on in console commands for EA3...
 - Plugins: Automatically use new console command names when old ones are attempted to write to console
 - Add auto retry to steamcmd updater
 - Start tracking console commands by name in `Omegga.Console....` like `Omegga.Console.Server.Players.GiveItem`
+- Deprecate minigame functions for EA3, add a getGamemode function for EA3
 
 ## 1.7.0 - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Future features go here
 
+## 1.8.0 - 2026-06-27
+
+Huge breaking changes on in console commands for EA3...
+
+- Plugins: Add fetch/crypto/atob/etc builtins to safe plugins
+- Plugins: Automatically use new console command names when old ones are attempted to write to console
+- Add auto retry to steamcmd updater
+- Start tracking console commands by name in `Omegga.Console....` like `Omegga.Console.Server.Players.GiveItem`
+
 ## 1.7.0 - 2026-06-14
 
 - Database: Replace NeDB with Drizzle ORM + better-sqlite3 for all database storage

--- a/frontend/src/css/style.scss
+++ b/frontend/src/css/style.scss
@@ -141,7 +141,7 @@ body {
       1px -1px 0 #000,
       -1px 1px 0 #000,
       1px 1px 0 #000;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   .user {

--- a/frontend/src/widgets/status/index.tsx
+++ b/frontend/src/widgets/status/index.tsx
@@ -31,22 +31,22 @@ export const StatusWidget = () => {
   return (
     <div className="status-widget">
       {status?.players && (
-        <Scroll className="players">
-          <div className="players-child">
-            <div className="stats">
-              <div className="stat">
-                <b>Name:</b> {status.serverName}
-              </div>
-              <div className="stat">
-                <b>Uptime:</b> {duration(status.time)}
-              </div>
-              <div className="stat">
-                <b>Bricks:</b> {status.bricks}
-              </div>
-              <div className="stat">
-                <b>Players:</b> {status.players.length}
-              </div>
+        <div className="players">
+          <div className="stats">
+            <div className="stat">
+              <b>Name:</b> {status.serverName}
             </div>
+            <div className="stat">
+              <b>Uptime:</b> {duration(status.time)}
+            </div>
+            <div className="stat">
+              <b>Bricks:</b> {status.bricks}
+            </div>
+            <div className="stat">
+              <b>Players:</b> {status.players.length}
+            </div>
+          </div>
+          <Scroll className="player-table">
             <table className="br-table">
               <thead>
                 <tr>
@@ -75,8 +75,8 @@ export const StatusWidget = () => {
                 ))}
               </tbody>
             </table>
-          </div>
-        </Scroll>
+          </Scroll>
+        </div>
       )}
       {!status?.players && (
         <Loader blur size="huge">

--- a/frontend/src/widgets/status/status.scss
+++ b/frontend/src/widgets/status/status.scss
@@ -10,8 +10,22 @@
   background-color: theme.$br-bg-secondary;
 
   .players {
-    .players-child {
-      @include mixins.column;
+    @include mixins.column;
+    flex: 1;
+    // allow the scroll area below to shrink instead of overflowing the widget
+    min-height: 0;
+    max-width: 100%;
+
+    // keep the stats pinned at the top, outside the scroll area
+    .stats {
+      flex-shrink: 0;
+    }
+
+    // fill the remaining vertical height; the scroller handles both axes
+    // (overflow-y: scroll promotes overflow-x to auto), so the horizontal
+    // scrollbar sits at the bottom of the widget
+    .player-table {
+      min-width: 0;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omegga",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omegga",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "ISC",
       "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",
@@ -2820,10 +2820,11 @@
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.14.181",
@@ -2832,20 +2833,22 @@
       "dev": true
     },
     "node_modules/@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -5369,10 +5372,14 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -7667,9 +7674,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7688,21 +7705,22 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^14.1.1",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^12.3.2",
-        "markdown-it-anchor": "^8.4.1",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -7897,12 +7915,23 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/linkify-react": {
@@ -8032,19 +8061,31 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -8089,10 +8130,11 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9010,6 +9052,16 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -11593,10 +11645,11 @@
       "dev": true
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.14.2",
@@ -14734,9 +14787,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true
     },
     "@types/lodash": {
@@ -14746,19 +14799,19 @@
       "dev": true
     },
     "@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "requires": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true
     },
     "@types/mime": {
@@ -16439,9 +16492,9 @@
       }
     },
     "entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
     },
     "envinfo": {
@@ -17968,9 +18021,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -17985,21 +18038,21 @@
       }
     },
     "jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^14.1.1",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^12.3.2",
-        "markdown-it-anchor": "^8.4.1",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -18148,12 +18201,12 @@
       }
     },
     "linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
       "requires": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "linkify-react": {
@@ -18253,16 +18306,17 @@
       }
     },
     "markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       }
     },
     "markdown-it-anchor": {
@@ -18294,9 +18348,9 @@
       }
     },
     "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "media-typer": {
@@ -18892,6 +18946,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
     "pvtsutils": {
@@ -20533,9 +20593,9 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omegga",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Brickadia server installer, updater, manager, wrapper, configurator, and automator",
   "engines": {
     "node": ">=23.0.0"

--- a/src/omegga/commandInjector.ts
+++ b/src/omegga/commandInjector.ts
@@ -83,10 +83,11 @@ const COMMANDS: InjectedCommands = {
    * Get a server status object containing bricks, time, players, player ping, player roles, etc
    */
   async getServerStatus(): Promise<IServerStatus | null> {
+    const { omegga } = this as unknown as LogWrangler;
     const statusLines = await (
       this as OmeggaLike
     ).watchLogChunk<RegExpMatchArray>(
-      'Server.Status',
+      omegga.Console.Server.Status,
       /^LogConsoleCommands: (.+)$/,
       {
         first: match => match[1].startsWith('Server Name:'),
@@ -153,10 +154,11 @@ const COMMANDS: InjectedCommands = {
    * @return Minigame List
    */
   async listMinigames(): Promise<IMinigameList> {
+    const { omegga } = this as unknown as LogWrangler;
     const minigameLines = await (
       this as OmeggaLike
     ).watchLogChunk<RegExpMatchArray>(
-      'Server.Minigames.List',
+      omegga.Console.Server.Minigames.List,
       /^LogConsoleCommands: (.+)$/,
       {
         first: match => match[1].startsWith('Minigame Count:'),

--- a/src/omegga/commandInjector.ts
+++ b/src/omegga/commandInjector.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { color, time } from '@util';
 import type LogWrangler from './logWrangler';
 import {
+  IGamemode,
   ILogMinigame,
   IMinigameList,
   IPlayerPositions,
@@ -74,6 +75,13 @@ const buildTableHeaderRegex = (header: string) => {
       .join('\\|'),
   ); // join the regexes with the |
 };
+/**
+ * CL at which the gamemode/team object model (`BP_GameStateBase_C` +
+ * `BRGameModeTeam`) replaced the old `BP_Ruleset_C`/`BP_Team_C` minigame model
+ * (same CL the `Server.Minigames.*` console commands were deprecated).
+ */
+const GAMEMODE_MODEL_CL = 14000;
+
 // A list of commands that can be injected to things with the log wrangler
 /**
  * List of injected commands
@@ -151,14 +159,36 @@ const COMMANDS: InjectedCommands = {
 
   /**
    * Get a list of minigames
+   * @deprecated minigames were replaced by a single gamemode (~CL14000); on
+   * modern servers this returns at most one entry with an empty `owner`.
+   * Prefer {@link getGamemode}.
    * @return Minigame List
    */
   async listMinigames(): Promise<IMinigameList> {
-    const { omegga } = this as unknown as LogWrangler;
+    const w = this as unknown as LogWrangler;
+
+    // Modern servers (>=CL14000): `Server.Minigames.List` was removed when
+    // gamemodes replaced minigames. Derive a single entry from the gamemode;
+    // there is no per-minigame `owner` anymore.
+    if (w.omegga.version >= GAMEMODE_MODEL_CL) {
+      const gamemode = await w.omegga.getGamemode();
+      return gamemode
+        ? [
+            {
+              index: 0,
+              name: gamemode.name,
+              numMembers: gamemode.members.length,
+              owner: { name: '', id: '' },
+            },
+          ]
+        : [];
+    }
+
+    // Legacy: the `Server.Minigames.List` console command + table parsing.
     const minigameLines = await (
       this as OmeggaLike
     ).watchLogChunk<RegExpMatchArray>(
-      omegga.Console.Server.Minigames.List,
+      w.omegga.Console.Server.Minigames.List,
       /^LogConsoleCommands: (.+)$/,
       {
         first: match => match[1].startsWith('Minigame Count:'),
@@ -283,10 +313,33 @@ const COMMANDS: InjectedCommands = {
   },
 
   /**
-   * get all minigames and their players (and the player's teams)
+   * get all minigames and their players (and the player's teams).
+   *
+   * On servers older than CL14000 this returns one entry per `BP_Ruleset_C`
+   * minigame. On modern servers minigames were replaced by a single gamemode,
+   * so this returns a single-element array (the gamemode and its teams) for
+   * backwards compatibility - prefer {@link getGamemode}.
    */
   async getMinigames(): Promise<ILogMinigame[]> {
-    // patterns to match the console logs
+    const w = this as unknown as LogWrangler;
+
+    // modern servers (>=CL14000) have a single gamemode in place of minigames
+    if (w.omegga.version >= GAMEMODE_MODEL_CL) {
+      const gamemode = await w.omegga.getGamemode();
+      return gamemode
+        ? [
+            {
+              name: gamemode.name,
+              ruleset: gamemode.gamestate,
+              index: 0,
+              members: gamemode.members,
+              teams: gamemode.teams,
+            },
+          ]
+        : [];
+    }
+
+    // legacy (<CL14000): one entry per BP_Ruleset_C minigame
     const ruleNameRegExp =
       /^(?<index>\d+)\) BP_Ruleset_C (.+):PersistentLevel.(?<ruleset>BP_Ruleset_C_\d+)\.RulesetName = (?<name>.*)$/;
     const ruleMembersRegExp =
@@ -307,9 +360,7 @@ const COMMANDS: InjectedCommands = {
           this.watchLogChunk<RegExpMatchArray>(
             'GetAll BP_Ruleset_C RulesetName',
             ruleNameRegExp,
-            {
-              first: 'index',
-            },
+            { first: 'index' },
           ),
           this.watchLogArray<
             { index: string; ruleset: string },
@@ -330,17 +381,13 @@ const COMMANDS: InjectedCommands = {
           this.watchLogChunk<RegExpMatchArray>(
             'GetAll BP_Team_C TeamName',
             teamNameRegExp,
-            {
-              first: 'index',
-            },
+            { first: 'index' },
           ),
           // team color in a5 is based on (B=255,G=255,R=255,A=255)
           this.watchLogChunk<RegExpMatchArray>(
             'GetAll BP_Team_C TeamColor',
             teamColorRegExp,
-            {
-              first: 'index',
-            },
+            { first: 'index' },
           ),
         ]);
 
@@ -405,12 +452,7 @@ const COMMANDS: InjectedCommands = {
             color: handleColor(
               _.pick(
                 teamColors.find(t => t.groups.team === m.item.team)?.groups ??
-                  ({
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                    a: 0,
-                  } as any),
+                  ({ r: 0, g: 0, b: 0, a: 0 } as any),
                 ['r', 'g', 'b', 'a'],
               ),
             ),
@@ -424,6 +466,97 @@ const COMMANDS: InjectedCommands = {
     } catch (e) {
       Logger.error('error getting minigames', e);
       return undefined;
+    }
+  },
+
+  /**
+   * get the single gamemode and its teams/players (modern servers, >=CL14000).
+   * Returns null on older servers (which instead have multiple minigames -
+   * use {@link getMinigames}).
+   */
+  async getGamemode(): Promise<IGamemode | null> {
+    const w = this as unknown as LogWrangler;
+    // the single-gamemode model only exists on modern servers
+    if (w.omegga.version < GAMEMODE_MODEL_CL) return null;
+
+    // patterns to match the console logs
+    const gameModeNameRegExp =
+      /^(?<index>\d+)\) BP_GameStateBase_C (.+):PersistentLevel\.(?<gamestate>BP_GameStateBase_C_\d+)\.GameModeName = (?<name>.*)$/;
+    const teamNameRegExp =
+      /^(?<index>\d+)\) BRGameModeTeam (.+):PersistentLevel\.(?<team>BRGameModeTeam_\d+)\.TeamName = (?<name>.*)$/;
+    const teamColorRegExp =
+      /^(?<index>\d+)\) BRGameModeTeam (.+):PersistentLevel\.(?<team>BRGameModeTeam_\d+)\.TeamColor = \(B=(?<b>\d+),G=(?<g>\d+),R=(?<r>\d+),A=(?<a>\d+)\)$/;
+    const teamMembersRegExp =
+      /^(?<index>\d+)\) BRGameModeTeam (.+):PersistentLevel\.(?<team>BRGameModeTeam_\d+)\.MemberStates =$/;
+    const playerStateRegExp =
+      /^\t(?<index>\d+): .*?BP_PlayerState_C'(.+):PersistentLevel\.(?<state>BP_PlayerState_C_\d+)'$/;
+
+    try {
+      // parse console output to get the gamemode and team info
+      const [gamemodes, teamNames, teamColors, teamMembers] = await Promise.all(
+        [
+          this.watchLogChunk<RegExpMatchArray>(
+            'GetAll BP_GameStateBase_C GameModeName',
+            gameModeNameRegExp,
+            { first: 'index', timeoutDelay: 250 },
+          ),
+          this.watchLogChunk<RegExpMatchArray>(
+            'GetAll BRGameModeTeam TeamName',
+            teamNameRegExp,
+            { first: 'index', timeoutDelay: 250 },
+          ),
+          // team color is (B=255,G=255,R=255,A=255)
+          this.watchLogChunk<RegExpMatchArray>(
+            'GetAll BRGameModeTeam TeamColor',
+            teamColorRegExp,
+            { first: 'index', timeoutDelay: 250 },
+          ),
+          this.watchLogArray<
+            { index: string; team: string },
+            { index: string; state: string }
+          >(
+            'GetAll BRGameModeTeam MemberStates',
+            teamMembersRegExp,
+            playerStateRegExp,
+          ),
+        ],
+      );
+
+      // there is a single gamemode (one BP_GameStateBase_C)
+      const gamemode = gamemodes[0]?.groups;
+      if (!gamemode) return null;
+
+      // build the teams from the name/color/member lookups
+      const teams = teamNames.map(t => {
+        const groups = t.groups!;
+        const id = groups.team;
+        const colorGroups = teamColors.find(c => c.groups?.team === id)?.groups;
+        return {
+          name: groups.name,
+          team: id,
+          // [r, g, b, a]
+          color: colorGroups
+            ? [colorGroups.r, colorGroups.g, colorGroups.b, colorGroups.a].map(
+                Number,
+              )
+            : [0, 0, 0, 0],
+          // resolve the players on this team from their player states
+          members: (teamMembers.find(m => m.item.team === id)?.members ?? [])
+            .map(m => this.getPlayer(m.state))
+            .filter((p): p is OmeggaPlayer => Boolean(p)),
+        };
+      });
+
+      return {
+        name: gamemode.name,
+        gamestate: gamemode.gamestate,
+        // the gamemode's members are every player across all teams
+        members: teams.flatMap(t => t.members),
+        teams,
+      };
+    } catch (e) {
+      Logger.error('error getting gamemode', e);
+      return null;
     }
   },
 };

--- a/src/omegga/commands.ts
+++ b/src/omegga/commands.ts
@@ -1,0 +1,678 @@
+// AUTO-GENERATED command name table. Maps each Brickadia console command to
+// its name across game versions so plugins/omegga can address commands without
+// hardcoding a name that changes between releases.
+//
+// At CL 14349 nearly every console command gained the `br.` prefix (and a
+// handful were restructured). Before that, the legacy names were used.
+// Minigames were deprecated at CL 14000 and replaced by GameMode commands;
+// the legacy Minigames commands still resolve but are no-ops on newer servers.
+//
+// Resolve the version-correct name with `omegga.Console`, e.g.
+// `omegga.Console.Bricks.Clear` -> "Bricks.Clear" or "br.Bricks.Clear".
+//
+// Where a command is both a value and a namespace (e.g. `br.DrawDebug.Colliders`
+// and `br.DrawDebug.Colliders.DrawCOM`), the command itself lives under `$`.
+
+/** CL version at which console commands gained the `br.` prefix. */
+const RENAME_VERSION = 14349;
+
+/** A console command whose name may differ across game versions. */
+export class ConsoleCommand {
+  /** @param versions [sinceVersion, name] pairs in ascending version order */
+  constructor(private readonly versions: readonly [number, string][]) {}
+
+  /** Resolve the command name for a given game CL version. */
+  resolve(version: number): string {
+    // unknown version (server not started / not detected yet) -> newest name
+    if (!version || version < 0)
+      return this.versions[this.versions.length - 1][1];
+    let name = this.versions[0][1];
+    for (const [since, candidate] of this.versions)
+      if (version >= since) name = candidate;
+    return name;
+  }
+
+  /** every name this command has gone by, across versions */
+  get names(): readonly string[] {
+    return this.versions.map(([, name]) => name);
+  }
+}
+
+/** Command renamed with the `br.` prefix at {@link RENAME_VERSION}. */
+const c = (legacy: string, current = legacy): ConsoleCommand =>
+  new ConsoleCommand(
+    legacy === current
+      ? [[0, legacy]]
+      : [
+          [0, legacy],
+          [RENAME_VERSION, current],
+        ],
+  );
+
+/** Command with explicit per-version names (ascending by version). */
+const cv = (versions: [number, string][]): ConsoleCommand =>
+  new ConsoleCommand(versions);
+
+/** The raw command table (leaves are version-aware {@link ConsoleCommand}s). */
+export const COMMAND_TABLE = {
+  Bricks: {
+    ActuallyReduce: c('Bricks.ActuallyReduce', 'br.Bricks.ActuallyReduce'),
+    Clear: c('Bricks.Clear', 'br.Bricks.Clear'),
+    ClearAll: c('Bricks.ClearAll', 'br.Bricks.ClearAll'),
+    ClearRegion: c('Bricks.ClearRegion', 'br.Bricks.ClearRegion'),
+    Cluster: {
+      EnableMergingDynamicGrids: c(
+        'Bricks.Cluster.EnableMergingDynamicGrids',
+        'br.Bricks.Cluster.EnableMergingDynamicGrids',
+      ),
+      EnableMergingGlobalGrid: c(
+        'Bricks.Cluster.EnableMergingGlobalGrid',
+        'br.Bricks.Cluster.EnableMergingGlobalGrid',
+      ),
+      MaxClusterHalfExtent: c(
+        'Bricks.Cluster.MaxClusterHalfExtent',
+        'br.Bricks.Cluster.MaxClusterHalfExtent',
+      ),
+      MaxClusterWeight: c(
+        'Bricks.Cluster.MaxClusterWeight',
+        'br.Bricks.Cluster.MaxClusterWeight',
+      ),
+      MaxSplitWeight: c(
+        'Bricks.Cluster.MaxSplitWeight',
+        'br.Bricks.Cluster.MaxSplitWeight',
+      ),
+      MinCollapseWeight: c(
+        'Bricks.Cluster.MinCollapseWeight',
+        'br.Bricks.Cluster.MinCollapseWeight',
+      ),
+      MinMergeThreshold: c(
+        'Bricks.Cluster.MinMergeThreshold',
+        'br.Bricks.Cluster.MinMergeThreshold',
+      ),
+      MinRootHalfExtent: c(
+        'Bricks.Cluster.MinRootHalfExtent',
+        'br.Bricks.Cluster.MinRootHalfExtent',
+      ),
+    },
+    ClusterMesh: {
+      CardCaching: c(
+        'Bricks.ClusterMesh.CardCaching',
+        'br.Bricks.ClusterMesh.CardCaching',
+      ),
+      DrawDistance: c(
+        'Bricks.ClusterMesh.DrawDistance',
+        'br.Bricks.ClusterMesh.DrawDistance',
+      ),
+      Hysteresis: c(
+        'Bricks.ClusterMesh.Hysteresis',
+        'br.Bricks.ClusterMesh.Hysteresis',
+      ),
+      Lod0KeepBias: c(
+        'Bricks.ClusterMesh.Lod0KeepBias',
+        'br.Bricks.ClusterMesh.Lod0KeepBias',
+      ),
+      MaxTransitionsPerFrame: c(
+        'Bricks.ClusterMesh.MaxTransitionsPerFrame',
+        'br.Bricks.ClusterMesh.MaxTransitionsPerFrame',
+      ),
+      MemoryBudgetBucketSize: c(
+        'Bricks.ClusterMesh.MemoryBudgetBucketSize',
+        'br.Bricks.ClusterMesh.MemoryBudgetBucketSize',
+      ),
+      MemoryBudgetMB: c(
+        'Bricks.ClusterMesh.MemoryBudgetMB',
+        'br.Bricks.ClusterMesh.MemoryBudgetMB',
+      ),
+      Residency: c(
+        'Bricks.ClusterMesh.Residency',
+        'br.Bricks.ClusterMesh.Residency',
+      ),
+      ResidencyConeHysteresis: c(
+        'Bricks.ClusterMesh.ResidencyConeHysteresis',
+        'br.Bricks.ClusterMesh.ResidencyConeHysteresis',
+      ),
+      ResidencyConeMargin: c(
+        'Bricks.ClusterMesh.ResidencyConeMargin',
+        'br.Bricks.ClusterMesh.ResidencyConeMargin',
+      ),
+      ResidencyWideFOV: c(
+        'Bricks.ClusterMesh.ResidencyWideFOV',
+        'br.Bricks.ClusterMesh.ResidencyWideFOV',
+      ),
+      ResidencyZoomHysteresisKillRate: c(
+        'Bricks.ClusterMesh.ResidencyZoomHysteresisKillRate',
+        'br.Bricks.ClusterMesh.ResidencyZoomHysteresisKillRate',
+      ),
+    },
+    DebugSaveFileScreenshots: c(
+      'Bricks.DebugSaveFileScreenshots',
+      'br.Bricks.DebugSaveFileScreenshots',
+    ),
+    DisableLoadWiresForLegacySave: c(
+      'Bricks.DisableLoadWiresForLegacySave',
+      'br.Bricks.DisableLoadWiresForLegacySave',
+    ),
+    DrawDebugOctree: c('Bricks.DrawDebugOctree', 'br.Bricks.DrawDebugOctree'),
+    DumpChunkStats: c('Bricks.DumpChunkStats', 'br.Bricks.DumpChunkStats'),
+    DumpCoverageStats: c(
+      'Bricks.DumpCoverageStats',
+      'br.Bricks.DumpCoverageStats',
+    ),
+    DumpGeometryStats: c(
+      'Bricks.DumpGeometryStats',
+      'br.Bricks.DumpGeometryStats',
+    ),
+    DumpGroupStats: c('Bricks.DumpGroupStats', 'br.Bricks.DumpGroupStats'),
+    EnableExtendedSort: c(
+      'Bricks.EnableExtendedSort',
+      'br.Bricks.EnableExtendedSort',
+    ),
+    EnableLumenCards: c(
+      'Bricks.EnableLumenCards',
+      'br.Bricks.EnableLumenCards',
+    ),
+    ExportModel: c('Bricks.ExportModel', 'br.Bricks.ExportModel'),
+    GenerateGates: c('BR.Bricks.GenerateGates'),
+    GenerateMathTables: c(
+      'Bricks.GenerateMathTables',
+      'br.Bricks.GenerateMathTables',
+    ),
+    GetOctreeStats: c('Bricks.GetOctreeStats', 'br.Bricks.GetOctreeStats'),
+    Load: c('Bricks.Load', 'br.Bricks.Load'),
+    LoadTemplate: c('Bricks.LoadTemplate'),
+    LODScreenSizeScale: c(
+      'Bricks.LODScreenSizeScale',
+      'br.Bricks.LODScreenSizeScale',
+    ),
+    LogClusterBuildTime: c(
+      'Bricks.LogClusterBuildTime',
+      'br.Bricks.LogClusterBuildTime',
+    ),
+    LogStreamSizes: c('Bricks.LogStreamSizes', 'br.Bricks.LogStreamSizes'),
+    MaxChunkClusterEntriesPerTick: c(
+      'Bricks.MaxChunkClusterEntriesPerTick',
+      'br.Bricks.MaxChunkClusterEntriesPerTick',
+    ),
+    MaxChunkEntries: c('Bricks.MaxChunkEntries', 'br.Bricks.MaxChunkEntries'),
+    MaxChunkUpdatesPerTick: c(
+      'Bricks.MaxChunkUpdatesPerTick',
+      'br.Bricks.MaxChunkUpdatesPerTick',
+    ),
+    MaxChunkUpdateTimePerTick: c(
+      'Bricks.MaxChunkUpdateTimePerTick',
+      'br.Bricks.MaxChunkUpdateTimePerTick',
+    ),
+    MaxClusterResultsToApplyPerTick: c(
+      'Bricks.MaxClusterResultsToApplyPerTick',
+      'br.Bricks.MaxClusterResultsToApplyPerTick',
+    ),
+    MaxSubscribed: c('br.MaxSubscribedBricks', 'br.Bricks.MaxSubscribed'),
+    OptimizeVertexCache: c(
+      'Bricks.OptimizeVertexCache',
+      'br.Bricks.OptimizeVertexCache',
+    ),
+    PrintOctreeLeafStats: c(
+      'Bricks.PrintOctreeLeafStats',
+      'br.Bricks.PrintOctreeLeafStats',
+    ),
+    RebuildClusters: c('Bricks.RebuildClusters', 'br.Bricks.RebuildClusters'),
+    RebuildMeshes: c('Bricks.RebuildMeshes', 'br.Bricks.RebuildMeshes'),
+    Save: c('Bricks.Save', 'br.Bricks.Save'),
+    SaveFileCompressionLevel: c(
+      'Bricks.SaveFileCompressionLevel',
+      'br.Bricks.SaveFileCompressionLevel',
+    ),
+    SaveFileReadBrickLimit: c(
+      'Bricks.SaveFileReadBrickLimit',
+      'br.Bricks.SaveFileReadBrickLimit',
+    ),
+    SaveFileReadComponentInstanceLimit: c(
+      'Bricks.SaveFileReadComponentInstanceLimit',
+      'br.Bricks.SaveFileReadComponentInstanceLimit',
+    ),
+    SaveFileReadComponentTypeLimit: c(
+      'Bricks.SaveFileReadComponentTypeLimit',
+      'br.Bricks.SaveFileReadComponentTypeLimit',
+    ),
+    SaveFileReadDimensionLimit: c(
+      'Bricks.SaveFileReadDimensionLimit',
+      'br.Bricks.SaveFileReadDimensionLimit',
+    ),
+    SaveFileReadOwnerLimit: c(
+      'Bricks.SaveFileReadOwnerLimit',
+      'br.Bricks.SaveFileReadOwnerLimit',
+    ),
+    SaveFileReadSizeLimit: c(
+      'Bricks.SaveFileReadSizeLimit',
+      'br.Bricks.SaveFileReadSizeLimit',
+    ),
+    SaveRegion: c('Bricks.SaveRegion', 'br.Bricks.SaveRegion'),
+    ValidateMathTables: c(
+      'Bricks.ValidateMathTables',
+      'br.Bricks.ValidateMathTables',
+    ),
+    Vehicle: {
+      AntiRollScale: c(
+        'Bricks.Vehicle.AntiRollScale',
+        'br.Bricks.Vehicle.AntiRollScale',
+      ),
+      ClientFullSim: c(
+        'Bricks.Vehicle.ClientFullSim',
+        'br.Bricks.Vehicle.ClientFullSim',
+      ),
+      DebugDraw: c('Bricks.Vehicle.DebugDraw', 'br.Bricks.Vehicle.DebugDraw'),
+    },
+    WheelEngine: {
+      VisualiseTurningCircles: c(
+        'Bricks.WheelEngine.VisualiseTurningCircles',
+        'br.Bricks.WheelEngine.VisualiseTurningCircles',
+      ),
+    },
+    WipeMirrorTables: c(
+      'Bricks.WipeMirrorTables',
+      'br.Bricks.WipeMirrorTables',
+    ),
+  },
+  BundleCompressionLevel: c('BR.BundleCompressionLevel'),
+  Bundles: {
+    AutoCloseDelay: c('Bundles.AutoCloseDelay', 'br.Bundles.AutoCloseDelay'),
+  },
+  Catalog: {
+    ClearCache: c('Catalog.ClearCache', 'br.Catalog.ClearCache'),
+    HideBlacklisted: c('Catalog.HideBlacklisted', 'br.Catalog.HideBlacklisted'),
+  },
+  Chat: {
+    Broadcast: c('Chat.Broadcast', 'br.Chat.Broadcast'),
+    Command: c('Chat.Command', 'br.Chat.Command'),
+    MessageForUnknownCommands: c(
+      'Chat.MessageForUnknownCommands',
+      'br.Chat.MessageForUnknownCommands',
+    ),
+    StatusMessage: c('Chat.StatusMessage', 'br.Chat.StatusMessage'),
+    Whisper: c('Chat.Whisper', 'br.Chat.Whisper'),
+  },
+  ComplexityWarning: {
+    BrickCount: c(
+      'br.BrickCountWarningThreshold',
+      'br.ComplexityWarning.BrickCount',
+    ),
+    FrozenEntityCount: c(
+      'br.FrozenEntityCountWarningThreshold',
+      'br.ComplexityWarning.FrozenEntityCount',
+    ),
+    UnfrozenEntityCount: c(
+      'br.UnfrozenEntityCountWarningThreshold',
+      'br.ComplexityWarning.UnfrozenEntityCount',
+    ),
+  },
+  Debug: {
+    CauseEnsure: c('CauseEnsure', 'br.Debug.CauseEnsure'),
+    CauseHang: c('CauseHang', 'br.Debug.CauseHang'),
+    ChangeBundleOwner: c('BR.Debug.ChangeBundleOwner'),
+    Crash: c('Crash', 'br.Debug.Crash'),
+    ListBundleOwners: c('BR.Debug.ListBundleOwners'),
+    TestMarkdown: c('TestMarkdown', 'br.Debug.TestMarkdown'),
+    TestMarkup: c('TestMarkup', 'br.Debug.TestMarkup'),
+  },
+  DrawDebug: {
+    BrickClusters: {
+      $: c('BR.DrawDebugBrickClusters', 'br.DrawDebug.BrickClusters'),
+      Neighbors: c(
+        'BR.DrawDebugBrickClusters.Neighbors',
+        'br.DrawDebug.BrickClusters.Neighbors',
+      ),
+      OctreeBounds: c(
+        'BR.DrawDebugBrickClusters.OctreeBounds',
+        'br.DrawDebug.BrickClusters.OctreeBounds',
+      ),
+    },
+    BrickClusterSplitTree: c(
+      'BR.DrawDebugBrickClusterSplitTree',
+      'br.DrawDebug.BrickClusterSplitTree',
+    ),
+    BrickLumenCards: c(
+      'BR.DrawDebugBrickLumenCards',
+      'br.DrawDebug.BrickLumenCards',
+    ),
+    ClientUpdates: c('BR.DrawDebugClientUpdates', 'br.DrawDebug.ClientUpdates'),
+    Colliders: {
+      $: c('BR.DrawDebugColliders', 'br.DrawDebug.Colliders'),
+      DrawCOM: c(
+        'BR.DrawDebugColliders.DrawCOM',
+        'br.DrawDebug.Colliders.DrawCOM',
+      ),
+      DrawCustomMass: c(
+        'BR.DrawDebugColliders.DrawCustomMass',
+        'br.DrawDebug.Colliders.DrawCustomMass',
+      ),
+    },
+    Constraints: c('BR.DrawDebugConstraints', 'br.DrawDebug.Constraints'),
+    Entities: {
+      $: c('BR.DrawDebugEntities', 'br.DrawDebug.Entities'),
+      Boxes: c('BR.DrawDebugEntities.Boxes', 'br.DrawDebug.Entities.Boxes'),
+      Dots: c('BR.DrawDebugEntities.Dots', 'br.DrawDebug.Entities.Dots'),
+    },
+    Lights: {
+      $: c('BR.DrawDebugLights', 'br.DrawDebug.Lights'),
+      RedThreshold: c(
+        'BR.DrawDebugLights.RedThreshold',
+        'br.DrawDebug.Lights.RedThreshold',
+      ),
+    },
+    Texts: c('BR.DrawDebugTexts', 'br.DrawDebug.Texts'),
+  },
+  EnableImgui: c('br.EnableImgui'),
+  EOS: {
+    AttemptLogin: c('BR.EOS.AttemptLogin'),
+    Disable: c('BR.EOS.Disable'),
+    SetSocketName: c('BR.EOS.SetSocketName'),
+  },
+  GPUMappedArray: {
+    MinBlocks: c('BR.GPUMappedArray.MinBlocks'),
+    ReservedHeadroomBlocks: c('BR.GPUMappedArray.ReservedHeadroomBlocks'),
+  },
+  Inspector: {
+    ShowFloatTest: c('Inspector.ShowFloatTest', 'br.Inspector.ShowFloatTest'),
+    ShowGraphics: c('Inspector.ShowGraphics', 'br.Inspector.ShowGraphics'),
+  },
+  Interview: c('BR.Interview'),
+  Iris: {
+    EnableMapDeltaSerialization: c('BR.Iris.EnableMapDeltaSerialization'),
+  },
+  LagIndicator: {
+    MinLatency: c('br.LagIndicatorMinLatency', 'br.LagIndicator.MinLatency'),
+    MinTimeSincePacket: c(
+      'br.LagIndicatorMinTimeSincePacket',
+      'br.LagIndicator.MinTimeSincePacket',
+    ),
+  },
+  Lua: {
+    Execute: c('Lua.Execute', 'br.Lua.Execute'),
+    ExecuteScript: c('Lua.ExecuteScript', 'br.Lua.ExecuteScript'),
+  },
+  Msgpack: {
+    Default: {
+      MaxContainerSize: c(
+        'msgpack.Default.MaxContainerSize',
+        'br.Msgpack.Default.MaxContainerSize',
+      ),
+      MaxDepth: c('msgpack.Default.MaxDepth', 'br.Msgpack.Default.MaxDepth'),
+      MaxEnumValueCount: c(
+        'msgpack.Default.MaxEnumValueCount',
+        'br.Msgpack.Default.MaxEnumValueCount',
+      ),
+      MaxFieldCount: c(
+        'msgpack.Default.MaxFieldCount',
+        'br.Msgpack.Default.MaxFieldCount',
+      ),
+      MaxFieldNameLength: c(
+        'msgpack.Default.MaxFieldNameLength',
+        'br.Msgpack.Default.MaxFieldNameLength',
+      ),
+      MaxFlatArraySize: c(
+        'msgpack.Default.MaxFlatArraySize',
+        'br.Msgpack.Default.MaxFlatArraySize',
+      ),
+      MaxNameLength: c(
+        'msgpack.Default.MaxNameLength',
+        'br.Msgpack.Default.MaxNameLength',
+      ),
+      MaxStringLength: c(
+        'msgpack.Default.MaxStringLength',
+        'br.Msgpack.Default.MaxStringLength',
+      ),
+      MaxTypeCount: c(
+        'msgpack.Default.MaxTypeCount',
+        'br.Msgpack.Default.MaxTypeCount',
+      ),
+    },
+  },
+  NudgePhysicsObject: c('BR.NudgePhysicsObject'),
+  Permissions: {
+    GrantRole: c('Permissions.GrantRole', 'br.Permissions.GrantRole'),
+    RevokeRole: c('Permissions.RevokeRole', 'br.Permissions.RevokeRole'),
+    Save: c('Permissions.Save', 'br.Permissions.Save'),
+  },
+  Physics: {
+    ForceFreezeDynamicGrids: c('BR.Physics.ForceFreezeDynamicGrids'),
+  },
+  Placer: {
+    LogRowTests: c('br.Placer.LogRowTests'),
+  },
+  PlayerParts: {
+    UseFastRender: c('br.PlayerParts.UseFastRender'),
+  },
+  Resizer: {
+    LogTests: c('br.Resizer.LogTests'),
+  },
+  RunHardwareBenchmark: c('BR.RunHardwareBenchmark'),
+  Server: {
+    Environment: {
+      LoadPreset: c(
+        'Server.Environment.LoadPreset',
+        'br.Server.Environment.LoadPreset',
+      ),
+      Reset: c('Server.Environment.Reset', 'br.Server.Environment.Reset'),
+      SavePreset: c(
+        'Server.Environment.SavePreset',
+        'br.Server.Environment.SavePreset',
+      ),
+    },
+    GameMode: {
+      EndRound: c('Server.GameMode.EndRound', 'br.Server.GameMode.EndRound'),
+      NextRound: c('Server.GameMode.NextRound', 'br.Server.GameMode.NextRound'),
+      PrintLeaderboard: c(
+        'Server.GameMode.PrintLeaderboard',
+        'br.Server.GameMode.PrintLeaderboard',
+      ),
+      Reset: c('Server.GameMode.Reset', 'br.Server.GameMode.Reset'),
+    },
+    Minigames: {
+      Delete: c('Server.Minigames.Delete'),
+      List: c('Server.Minigames.List'),
+      LoadPreset: c('Server.Minigames.LoadPreset'),
+      NextRound: cv([
+        [0, 'Server.Minigames.NextRound'],
+        [14000, 'Server.GameMode.NextRound'],
+        [14349, 'br.Server.GameMode.NextRound'],
+      ]),
+      Reset: cv([
+        [0, 'Server.Minigames.Reset'],
+        [14000, 'Server.GameMode.Reset'],
+        [14349, 'br.Server.GameMode.Reset'],
+      ]),
+      SavePreset: c('Server.Minigames.SavePreset'),
+    },
+    PlayerPositions: c('Server.PlayerPositions', 'br.Server.PlayerPositions'),
+    Players: {
+      Damage: c('Server.Players.Damage', 'br.Server.Players.Damage'),
+      GiveItem: c('Server.Players.GiveItem', 'br.Server.Players.GiveItem'),
+      Kill: c('Server.Players.Kill', 'br.Server.Players.Kill'),
+      PrintAllLeaderboardValues: c(
+        'Server.Players.PrintAllLeaderboardValues',
+        'br.Server.Players.PrintAllLeaderboardValues',
+      ),
+      PrintLeaderboardValue: c(
+        'Server.Players.PrintLeaderboardValue',
+        'br.Server.Players.PrintLeaderboardValue',
+      ),
+      RemoveItem: c(
+        'Server.Players.RemoveItem',
+        'br.Server.Players.RemoveItem',
+      ),
+      SetLeaderboardValue: c(
+        'Server.Players.SetLeaderboardValue',
+        'br.Server.Players.SetLeaderboardValue',
+      ),
+      SetMinigame: c('Server.Players.SetMinigame'),
+      SetTeam: c('Server.Players.SetTeam', 'br.Server.Players.SetTeam'),
+    },
+    Status: c('Server.Status', 'br.Server.Status'),
+    Teams: {
+      PrintAllLeaderboardValues: c(
+        'Server.Teams.PrintAllLeaderboardValues',
+        'br.Server.Teams.PrintAllLeaderboardValues',
+      ),
+      PrintLeaderboardValue: c(
+        'Server.Teams.PrintLeaderboardValue',
+        'br.Server.Teams.PrintLeaderboardValue',
+      ),
+    },
+  },
+  Text: {
+    FlushRecoveryFrames: c('br.Text.FlushRecoveryFrames'),
+    MaxCharsPolledPerFrame: c('br.Text.MaxCharsPolledPerFrame'),
+    MaxCharsShapedPerFrame: c('br.Text.MaxCharsShapedPerFrame'),
+  },
+  Thumbnails: {
+    WipeCache: c('BR.Thumbnails.WipeCache'),
+  },
+  Voice: {
+    DebugDecode: c('voice.DebugDecode', 'br.Voice.DebugDecode'),
+    SyntheticInput: c('voice.SyntheticInput', 'br.Voice.SyntheticInput'),
+    TestJitter: c('voice.TestJitter', 'br.Voice.TestJitter'),
+  },
+  Weapons: {
+    DebugFiringVectors: c(
+      'weapons.DebugFiringVectors',
+      'br.Weapons.DebugFiringVectors',
+    ),
+    DebugHitValidation: c(
+      'weapons.DebugHitValidation',
+      'br.Weapons.DebugHitValidation',
+    ),
+    EnableHitValidation: c(
+      'weapons.EnableHitValidation',
+      'br.Weapons.EnableHitValidation',
+    ),
+    LatencyCompensationDelayMethod: c(
+      'weapons.LatencyCompensationDelayMethod',
+      'br.Weapons.LatencyCompensationDelayMethod',
+    ),
+    LatencyCompensationLimit: c(
+      'weapons.LatencyCompensationLimit',
+      'br.Weapons.LatencyCompensationLimit',
+    ),
+    LatencyCompensationOffset: c(
+      'weapons.LatencyCompensationOffset',
+      'br.Weapons.LatencyCompensationOffset',
+    ),
+    ProjectileClientLatencyCompensationEnabled: c(
+      'weapons.ProjectileClientLatencyCompensationEnabled',
+      'br.Weapons.ProjectileClientLatencyCompensationEnabled',
+    ),
+    ProjectileLatencyCompensationEnabled: c(
+      'weapons.ProjectileLatencyCompensationEnabled',
+      'br.Weapons.ProjectileLatencyCompensationEnabled',
+    ),
+    ProjectilePredictionEnabled: c(
+      'weapons.ProjectilePredictionEnabled',
+      'br.Weapons.ProjectilePredictionEnabled',
+    ),
+  },
+  WireFuzzer: {
+    ClearBreakpoints: c('BR.WireFuzzer.ClearBreakpoints'),
+    ComponentsPerTick: c('BR.WireFuzzer.ComponentsPerTick'),
+    DisconnectBeforeConnect: c('BR.WireFuzzer.DisconnectBeforeConnect'),
+    GatesPerTick: c('BR.WireFuzzer.GatesPerTick'),
+    MaxComponents: c('BR.WireFuzzer.MaxComponents'),
+    MaxGates: c('BR.WireFuzzer.MaxGates'),
+    MaxWires: c('BR.WireFuzzer.MaxWires'),
+    ModificationsPerTick: c('BR.WireFuzzer.ModificationsPerTick'),
+    RerouteDuplication: c('BR.WireFuzzer.RerouteDuplication'),
+    Start: c('BR.WireFuzzer.Start'),
+    StartWithSeed: c('BR.WireFuzzer.StartWithSeed'),
+    Stop: c('BR.WireFuzzer.Stop'),
+    WiresPerTick: c('BR.WireFuzzer.WiresPerTick'),
+  },
+  WireGraphViz: c('BR.WireGraphViz'),
+  WireRenderer: {
+    EnablePorts: c('BR.WireRenderer.EnablePorts'),
+    EnableWires: c('BR.WireRenderer.EnableWires'),
+  },
+  World: {
+    CreateEmpty: c('BR.World.CreateEmpty'),
+    ListRevisions: c('BR.World.ListRevisions'),
+    Load: c('BR.World.Load'),
+    LoadAdditive: c('BR.World.LoadAdditive'),
+    LoadRevision: c('BR.World.LoadRevision'),
+    Save: c('BR.World.Save'),
+    SaveAs: c('BR.World.SaveAs'),
+  },
+  WorldSerializer: {
+    LogPrefabLoads: c('BR.WorldSerializer.LogPrefabLoads'),
+    RedirectLegacyWheelJoints: c(
+      'BR.WorldSerializer.RedirectLegacyWheelJoints',
+    ),
+    WipeOwnershipOnLoad: c('BR.WorldSerializer.WipeOwnershipOnLoad'),
+  },
+} satisfies CommandTree;
+
+type CommandTree = { [key: string]: ConsoleCommand | CommandTree };
+
+/** Recursively turn a {@link CommandTree} into resolved command-name strings. */
+type Resolved<T> = T extends ConsoleCommand
+  ? string
+  : { [K in keyof T]: Resolved<T[K]> };
+
+/**
+ * Version-resolved console command names, nested by namespace.
+ * Every leaf is the command string for the running game version.
+ */
+export type ConsoleCommands = Resolved<typeof COMMAND_TABLE>;
+
+const resolveTree = (tree: CommandTree, version: number): unknown => {
+  const out: Record<string, unknown> = {};
+  for (const key in tree) {
+    const value = tree[key];
+    out[key] =
+      value instanceof ConsoleCommand
+        ? value.resolve(version)
+        : resolveTree(value, version);
+  }
+  return out;
+};
+
+/** Build the resolved {@link ConsoleCommands} map for a game CL version. */
+export const resolveConsoleCommands = (version: number): ConsoleCommands =>
+  resolveTree(COMMAND_TABLE, version) as ConsoleCommands;
+
+// Reverse lookup: every known command name (lowercased, across all versions)
+// -> the command. First write wins so canonical commands keep priority over
+// the deprecated aliases injected later in the table.
+const COMMAND_LOOKUP = new Map<string, ConsoleCommand>();
+const indexTree = (tree: CommandTree): void => {
+  for (const key in tree) {
+    const value = tree[key];
+    if (value instanceof ConsoleCommand) {
+      for (const name of value.names) {
+        const lower = name.toLowerCase();
+        if (!COMMAND_LOOKUP.has(lower)) COMMAND_LOOKUP.set(lower, value);
+      }
+    } else {
+      indexTree(value);
+    }
+  }
+};
+indexTree(COMMAND_TABLE);
+
+/**
+ * Rewrite a console command line so a stale command name resolves to the name
+ * the running game version expects. The first word (up to the first space) is
+ * matched case-insensitively against every known command name; if it maps to a
+ * command whose version-correct name differs, that word is swapped. Lines that
+ * don't start with a known command are returned unchanged.
+ */
+export const migrateConsoleCommand = (
+  line: string,
+  version: number,
+): string => {
+  const space = line.indexOf(' ');
+  const head = space === -1 ? line : line.slice(0, space);
+  const command = COMMAND_LOOKUP.get(head.toLowerCase());
+  if (!command) return line;
+  const resolved = command.resolve(version);
+  // already a valid name for this version (console names are case-insensitive)
+  if (resolved.toLowerCase() === head.toLowerCase()) return line;
+  return space === -1 ? resolved : resolved + line.slice(space);
+};

--- a/src/omegga/player.ts
+++ b/src/omegga/player.ts
@@ -143,7 +143,8 @@ class Player implements OmeggaPlayer {
 
   static kill(omegga: OmeggaLike, target: string | OmeggaPlayer) {
     if (typeof target === 'string') target = omegga.getPlayer(target);
-    if (target?.name) omegga.writeln(`Server.Players.Kill "${target?.name}"`);
+    if (target?.name)
+      omegga.writeln(`${omegga.Console.Server.Players.Kill} "${target?.name}"`);
   }
 
   static damage(
@@ -154,7 +155,9 @@ class Player implements OmeggaPlayer {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (amount === 0) return;
     if (target?.name)
-      omegga.writeln(`Server.Players.Damage "${target?.name}" ${amount}`);
+      omegga.writeln(
+        `${omegga.Console.Server.Players.Damage} "${target?.name}" ${amount}`,
+      );
   }
 
   static heal(
@@ -174,7 +177,9 @@ class Player implements OmeggaPlayer {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (!item) return;
     if (target?.name)
-      omegga.writeln(`Server.Players.GiveItem "${target?.name}" ${item}`);
+      omegga.writeln(
+        `${omegga.Console.Server.Players.GiveItem} "${target?.name}" ${item}`,
+      );
   }
 
   static takeItem(
@@ -185,7 +190,9 @@ class Player implements OmeggaPlayer {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (!item) return;
     if (target?.name)
-      omegga.writeln(`Server.Players.RemoveItem "${target?.name}" ${item}`);
+      omegga.writeln(
+        `${omegga.Console.Server.Players.RemoveItem} "${target?.name}" ${item}`,
+      );
   }
 
   static setTeam(
@@ -195,7 +202,9 @@ class Player implements OmeggaPlayer {
   ) {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (target?.name)
-      omegga.writeln(`Server.Players.SetTeam "${target?.name}" ${teamIndex}`);
+      omegga.writeln(
+        `${omegga.Console.Server.Players.SetTeam} "${target?.name}" ${teamIndex}`,
+      );
   }
 
   static setMinigame(
@@ -205,7 +214,9 @@ class Player implements OmeggaPlayer {
   ) {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (target?.name)
-      omegga.writeln(`Server.Players.SetMinigame "${target?.name}" ${index}`);
+      omegga.writeln(
+        `${omegga.Console.Server.Players.SetMinigame} "${target?.name}" ${index}`,
+      );
   }
 
   static setScore(
@@ -217,7 +228,7 @@ class Player implements OmeggaPlayer {
     if (typeof target === 'string') target = omegga.getPlayer(target);
     if (target?.name)
       omegga.writeln(
-        `Server.Players.SetLeaderboardValue "${target?.name}" ${minigameIndex} ${score}`,
+        `${omegga.Console.Server.Players.SetLeaderboardValue} "${target?.name}" ${minigameIndex} ${score}`,
       );
   }
 
@@ -248,7 +259,7 @@ class Player implements OmeggaPlayer {
         timeoutDelay: 1000,
         exec: () =>
           omegga.writeln(
-            `Server.Players.PrintLeaderboardValue "${name}" ${minigameIndex}`,
+            `${omegga.Console.Server.Players.PrintLeaderboardValue} "${name}" ${minigameIndex}`,
           ),
       },
     );
@@ -265,7 +276,7 @@ class Player implements OmeggaPlayer {
     if (!target?.name) return null;
 
     omegga.writeln(
-      `Server.Players.SetLeaderboardValue "${target.name}" "${key}" "${value}"`,
+      `${omegga.Console.Server.Players.SetLeaderboardValue} "${target.name}" "${key}" "${value}"`,
     );
   }
 
@@ -295,7 +306,7 @@ class Player implements OmeggaPlayer {
           timeoutDelay: 1000,
           exec: () =>
             omegga.writeln(
-              `Server.Players.PrintLeaderboardValue "${target.name}" "${key}"`,
+              `${omegga.Console.Server.Players.PrintLeaderboardValue} "${target.name}" "${key}"`,
             ),
         },
       )

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -13,6 +13,7 @@ import {
   BRRoleSetup,
 } from '@brickadia/types';
 import commandInjector from '@omegga/commandInjector';
+import { ConsoleCommands, resolveConsoleCommands } from '@omegga/commands';
 import LogWrangler from '@omegga/logWrangler';
 import Player from '@omegga/player';
 import Omegga from '@omegga/server';
@@ -111,6 +112,19 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   writeln: (line: string) => void;
   version: number;
   players: Player[];
+
+  /** memoized version-resolved console commands ({@link Console}) */
+  #console: { version: number; commands: ConsoleCommands };
+
+  /** version-resolved Brickadia console command names, nested by namespace */
+  get Console(): ConsoleCommands {
+    if (this.#console?.version !== this.version)
+      this.#console = {
+        version: this.version,
+        commands: resolveConsoleCommands(this.version),
+      };
+    return this.#console.commands;
+  }
 
   host: { id: string; name: string };
 

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -18,6 +18,7 @@ import LogWrangler from '@omegga/logWrangler';
 import Player from '@omegga/player';
 import Omegga from '@omegga/server';
 import {
+  IGamemode,
   ILogMinigame,
   IMinigameList,
   IPlayerPositions,
@@ -250,6 +251,9 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   }
   getMinigames(): Promise<ILogMinigame[]> {
     throw badBorrow('getMinigames');
+  }
+  getGamemode(): Promise<IGamemode | null> {
+    throw badBorrow('getGamemode');
   }
   getPlayers(): {
     id: string;

--- a/src/omegga/plugin/plugin_node_safe/worker.ts
+++ b/src/omegga/plugin/plugin_node_safe/worker.ts
@@ -291,11 +291,35 @@ async function createVm(
     }
   }
   if (vm !== undefined) return [false, 'vm is already created'];
+  const sandbox: Record<string, unknown> = {};
+  for (const name of [
+    'fetch',
+    'Headers',
+    'Request',
+    'Response',
+    'FormData',
+    'Blob',
+    'File',
+    'AbortController',
+    'AbortSignal',
+    'URL',
+    'URLSearchParams',
+    'TextEncoder',
+    'TextDecoder',
+    'crypto',
+    'structuredClone',
+    'queueMicrotask',
+    'btoa',
+    'atob',
+  ]) {
+    const value = (globalThis as Record<string, unknown>)[name];
+    if (value !== undefined) sandbox[name] = value;
+  }
 
   // create the vm
   vm = new NodeVM({
     console: 'redirect',
-    sandbox: {},
+    sandbox,
     require: {
       external,
       builtin,

--- a/src/omegga/plugin/plugin_node_safe/worker.ts
+++ b/src/omegga/plugin/plugin_node_safe/worker.ts
@@ -157,13 +157,29 @@ async function createVm(
                 { request }: ExternalItemFunctionData,
                 callback: (err?: Error, result?: string) => void,
               ) {
+                // native addons: resolve the .node binary relative to the plugin
                 if (request.match(/\.node$/)) {
                   return callback(
                     null,
                     'commonjs ' + path.resolve(pluginPath, request),
                   );
                 }
-                callback();
+                // bundle the plugin's own sources: relative/absolute imports and
+                // the `src` alias all stay in the bundle
+                if (
+                  request.startsWith('.') ||
+                  request === 'src' ||
+                  request.startsWith('src/') ||
+                  path.isAbsolute(request)
+                ) {
+                  return callback();
+                }
+                // everything else is a bare specifier (a node builtin or a
+                // node_modules package). Leave it as a runtime require instead
+                // of bundling it, so native/wasm dependencies (dockerode, ssh2,
+                // grpc, ...) load via real node. The NodeVM permits these via
+                // `external: true` and the plugin's access list.
+                callback(null, 'commonjs ' + request);
               },
             ],
             resolve: {

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -31,6 +31,7 @@ import MATCHERS from './matchers';
 import Player from './player';
 import { PluginLoader } from './plugin';
 import {
+  IGamemode,
   ILogMinigame,
   IMinigameList,
   IOmeggaOptions,
@@ -93,6 +94,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   listMinigames: () => Promise<IMinigameList>;
   getAllPlayerPositions: () => Promise<IPlayerPositions>;
   getMinigames: () => Promise<ILogMinigame[]>;
+  getGamemode: () => Promise<IGamemode | null>;
 
   /**
    * Omegga instance

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -26,6 +26,7 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'path';
 import { AutoRestartConfig } from '..';
 import commandInjector from './commandInjector';
+import { ConsoleCommands, resolveConsoleCommands } from './commands';
 import MATCHERS from './matchers';
 import Player from './player';
 import { PluginLoader } from './plugin';
@@ -61,6 +62,23 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   options: IOmeggaOptions;
 
   version: number;
+
+  /** memoized version-resolved console commands ({@link Console}) */
+  #console: { version: number; commands: ConsoleCommands };
+
+  /**
+   * version-resolved Brickadia console command names, nested by namespace.
+   * e.g. `omegga.Console.Bricks.Clear` -> "Bricks.Clear" or "br.Bricks.Clear"
+   * depending on the running game version.
+   */
+  get Console(): ConsoleCommands {
+    if (this.#console?.version !== this.version)
+      this.#console = {
+        version: this.version,
+        commands: resolveConsoleCommands(this.version),
+      };
+    return this.#console.commands;
+  }
 
   host?: { id: string; name: string };
   players: OmeggaPlayer[];
@@ -189,7 +207,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       this.started = true;
       this.starting = false;
       this.currentMap = map;
-      this.writeln('Chat.MessageForUnknownCommands 0');
+      this.writeln(`${this.Console.Chat.MessageForUnknownCommands} 0`);
 
       this.restoreServer();
     });
@@ -324,7 +342,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
         if (index > -1) {
           const { position } = players[index];
           this.writeln(
-            `Chat.Command /TP "${player.name}" ${position.join(' ')} 0`,
+            `${this.Console.Chat.Command} /TP "${player.name}" ${position.join(' ')} 0`,
           );
 
           // remove the entry
@@ -434,7 +452,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     messages
       .flatMap(m => m.toString().split('\n'))
       .filter(m => m.length < 512)
-      .forEach(m => this.writeln(`Chat.Broadcast ${m}`));
+      .forEach(m => this.writeln(`${this.Console.Chat.Broadcast} ${m}`));
   }
 
   whisper(target: string | OmeggaPlayer, ...messages: string[]) {
@@ -447,7 +465,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       .filter(m => m.length < 512)
       .forEach(m =>
         this.writeln(
-          `Chat.Whisper "${(target as { name: string }).name}" ${m}`,
+          `${this.Console.Chat.Whisper} "${(target as { name: string }).name}" ${m}`,
         ),
       );
   }
@@ -459,7 +477,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     // whisper the messages to that player
     if (message.length > 512) return;
     this.writeln(
-      `Chat.StatusMessage "${(target as { name: string }).name}" ${message}`,
+      `${this.Console.Chat.StatusMessage} "${(target as { name: string }).name}" ${message}`,
     );
   }
 
@@ -524,24 +542,26 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   }
 
   saveMinigame(index: number, name: string) {
-    this.writeln(`Server.Minigames.SavePreset ${index} "${name}"`);
+    this.writeln(
+      `${this.Console.Server.Minigames.SavePreset} ${index} "${name}"`,
+    );
   }
 
   deleteMinigame(index: number) {
-    this.writeln(`Server.Minigames.Delete ${index}`);
+    this.writeln(`${this.Console.Server.Minigames.Delete} ${index}`);
   }
 
   resetMinigame(index: number) {
-    this.writeln(`Server.Minigames.Reset ${index}`);
+    this.writeln(`${this.Console.Server.Minigames.Reset} ${index}`);
   }
 
   nextRoundMinigame(index: number) {
-    this.writeln(`Server.Minigames.NextRound ${index}`);
+    this.writeln(`${this.Console.Server.Minigames.NextRound} ${index}`);
   }
 
   loadMinigame(presetName: string, owner = '') {
     this.writeln(
-      `Server.Minigames.LoadPreset "${presetName}" ${owner ? `"${owner}"` : ''}`,
+      `${this.Console.Server.Minigames.LoadPreset} "${presetName}" ${owner ? `"${owner}"` : ''}`,
     );
   }
 
@@ -555,13 +575,16 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   }
 
   resetEnvironment() {
-    this.writeln(`Server.Environment.Reset`);
+    this.writeln(`${this.Console.Server.Environment.Reset}`);
   }
 
   async saveEnvironment(presetName: string): Promise<void> {
     await this.addWatcher(/Environment preset saved.$/, {
       // request the pawn for this player's controller (should only be one)
-      exec: () => this.writeln(`Server.Environment.SavePreset "${presetName}"`),
+      exec: () =>
+        this.writeln(
+          `${this.Console.Server.Environment.SavePreset} "${presetName}"`,
+        ),
       timeoutDelay: 100,
     });
   }
@@ -592,7 +615,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   }
 
   loadEnvironment(presetName: string) {
-    this.writeln(`Server.Environment.LoadPreset ${presetName}`);
+    this.writeln(`${this.Console.Server.Environment.LoadPreset} ${presetName}`);
   }
 
   loadEnvironmentData(
@@ -647,7 +670,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     if (!target) return;
 
-    this.writeln(`Bricks.Clear ${target} ${quiet ? 1 : ''}`);
+    this.writeln(`${this.Console.Bricks.Clear} ${target} ${quiet ? 1 : ''}`);
   }
 
   clearRegion(
@@ -671,14 +694,14 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     }
 
     this.writeln(
-      `Bricks.ClearRegion ${region.center.join(' ')} ${region.extent.join(
+      `${this.Console.Bricks.ClearRegion} ${region.center.join(' ')} ${region.extent.join(
         ' ',
       )}${target}`,
     );
   }
 
   clearAllBricks(quiet = false) {
-    this.writeln(`Bricks.ClearAll ${quiet ? 1 : ''}`);
+    this.writeln(`${this.Console.Bricks.ClearAll} ${quiet ? 1 : ''}`);
   }
 
   saveBricks(
@@ -696,11 +719,11 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     if (region?.center && region?.extent)
       this.writeln(
-        `Bricks.SaveRegion ${saveName} ${region.center.join(
+        `${this.Console.Bricks.SaveRegion} ${saveName} ${region.center.join(
           ' ',
         )} ${region.extent.join(' ')}`,
       );
-    else this.writeln(`Bricks.Save ${saveName}`);
+    else this.writeln(`${this.Console.Bricks.Save} ${saveName}`);
   }
 
   async saveBricksAsync(
@@ -719,10 +742,10 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     const command =
       region?.center && region?.extent
-        ? `Bricks.SaveRegion ${saveNameClean} ${region.center.join(
+        ? `${this.Console.Bricks.SaveRegion} ${saveNameClean} ${region.center.join(
             ' ',
           )} ${region.extent.join(' ')}`
-        : `Bricks.Save ${saveNameClean}`;
+        : `${this.Console.Bricks.Save} ${saveNameClean}`;
 
     // wait for the server to save the file
     await this.watchLogChunk(command, /^(LogBrickSerializer|LogTemp): (.+)$/, {
@@ -754,9 +777,9 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       saveName = `"${saveName}"`;
 
     this.writeln(
-      `Bricks.Load ${saveName} ${offX} ${offY} ${offZ} ${quiet ? 1 : 0} ${
-        correctPalette ? 1 : 0
-      } ${correctCustom ? 1 : 0}`,
+      `${this.Console.Bricks.Load} ${saveName} ${offX} ${offY} ${offZ} ${
+        quiet ? 1 : 0
+      } ${correctPalette ? 1 : 0} ${correctCustom ? 1 : 0}`,
     );
   }
 
@@ -779,7 +802,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       saveName = `"${saveName}"`;
 
     this.writeln(
-      `Bricks.LoadTemplate ${saveName} ${offX} ${offY} ${offZ}  ${
+      `${this.Console.Bricks.LoadTemplate} ${saveName} ${offX} ${offY} ${offZ}  ${
         correctPalette ? 1 : 0
       } ${correctCustom ? 1 : 0} "${player.name}"`,
     );
@@ -831,7 +854,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     */
     let numRevisions = 0;
     const revisionsRaw = await this.watchLogChunk<RegExpMatchArray>(
-      `BR.World.ListRevisions "${worldName}"`,
+      `${this.Console.World.ListRevisions} "${worldName}"`,
       /^LogBRBundleManager: (There are (?<numRevisions>\d+) revisions|Revision (?<revision>\d+) - (?<date>[\d.-]+): (?<note>.+))$/,
       {
         last: match => Number(match.groups.reverse) === numRevisions,
@@ -870,7 +893,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   async loadWorld(worldName: string): Promise<boolean> {
     worldName = worldName.replace(/\.brdb$/i, '');
     if (!worldName || !this.getWorldPath(worldName)) return false;
-    this.writeln(`BR.World.Load "${worldName}"`);
+    this.writeln(`${this.Console.World.Load} "${worldName}"`);
     const res = await Promise.race([
       // wait for the map to change
       new Promise(resolve =>
@@ -892,7 +915,9 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     if (typeof revision !== 'number' || revision < 1) {
       throw new Error(`Invalid revision number: ${revision}`);
     }
-    this.writeln(`BR.World.LoadRevision "${worldName}" ${revision}`);
+    this.writeln(
+      `${this.Console.World.LoadRevision} "${worldName}" ${revision}`,
+    );
     const res = await Promise.race([
       // wait for the map to change
       new Promise(resolve =>
@@ -931,7 +956,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
         },
         {
           exec: () => {
-            this.writeln(`BR.World.SaveAs "${worldName}"`);
+            this.writeln(`${this.Console.World.SaveAs} "${worldName}"`);
           },
           timeoutDelay: 2000,
         },
@@ -961,7 +986,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
         },
         {
           exec: () => {
-            this.writeln(`BR.World.Save 0`);
+            this.writeln(`${this.Console.World.Save} 0`);
           },
           timeoutDelay: 2000,
         },
@@ -992,7 +1017,9 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
         },
         {
           exec: () => {
-            this.writeln(`BR.World.CreateEmpty "${worldName}" ${map}`);
+            this.writeln(
+              `${this.Console.World.CreateEmpty} "${worldName}" ${map}`,
+            );
           },
           timeoutDelay: 2000,
         },
@@ -1045,7 +1072,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     // wait for the server to finish reading the save
     await this.watchLogChunk(
-      `Bricks.Load "${saveFile}" ${offX} ${offY} ${offZ} ${quiet ? 1 : 0} ${
+      `${this.Console.Bricks.Load} "${saveFile}" ${offX} ${offY} ${offZ} ${quiet ? 1 : 0} ${
         correctPalette ? 1 : 0
       } ${correctCustom ? 1 : 0}`,
       /^LogBrickSerializer: (.+)$/,
@@ -1085,7 +1112,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
 
     // wait for the server to finish reading the save
     await this.watchLogChunk(
-      `Bricks.LoadTemplate "${saveFile}" ${offX} ${offY} ${offZ} ${
+      `${this.Console.Bricks.LoadTemplate} "${saveFile}" ${offX} ${offY} ${offZ} ${
         correctPalette ? 1 : 0
       } ${correctCustom ? 1 : 0} "${player.name}"`,
       /^LogBrickSerializer: (.+)$/,

--- a/src/omegga/types.ts
+++ b/src/omegga/types.ts
@@ -52,3 +52,24 @@ export type ILogMinigame = {
     members: OmeggaPlayer[];
   }[];
 };
+
+/**
+ * The single gamemode that replaced minigames (~CL14000). Owns the teams and
+ * the players within them.
+ */
+export type IGamemode = {
+  /** the gamemode name (e.g. "Sandbox") */
+  name: string;
+  /** the BP_GameStateBase_C object id */
+  gamestate: string;
+  /** every player across all teams */
+  members: OmeggaPlayer[];
+  teams: {
+    name: string;
+    /** the BRGameModeTeam object id */
+    team: string;
+    /** [r, g, b, a] */
+    color: number[];
+    members: OmeggaPlayer[];
+  }[];
+};

--- a/src/omegga/wrapper.ts
+++ b/src/omegga/wrapper.ts
@@ -8,6 +8,7 @@ import BrickadiaServer from '@brickadia/server';
 import { IConfig } from '@config/types';
 import EventEmitter from 'events';
 import path from 'path';
+import { migrateConsoleCommand } from './commands';
 import LogWrangler from './logWrangler';
 import type Omegga from './server';
 
@@ -55,7 +56,12 @@ class OmeggaWrapper extends EventEmitter {
     this.#server.write(str);
   }
   writeln(str: string) {
-    this.#server.writeln(str);
+    // auto-migrate stale console command names to the running game version's
+    // name (e.g. `Bricks.Clear` -> `br.Bricks.Clear`) so older plugins keep
+    // working. OmeggaWrapper is never used without Omegga, so `version` exists.
+    this.#server.writeln(
+      migrateConsoleCommand(str, (this as unknown as Omegga).version),
+    );
   }
   start() {
     return this.#server.start();

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   BRRoleAssignments,
   BRRoleSetup,
 } from '@brickadia/types';
+import { ConsoleCommands } from '@omegga/commands';
 import {
   ILogMinigame,
   IMinigameList,
@@ -23,6 +24,7 @@ declare global {
 
 export * from '@brickadia/types';
 export * from '@omegga/types';
+export type { ConsoleCommands } from '@omegga/commands';
 export { OmeggaPlugin };
 
 export type OL = OmeggaLike;
@@ -494,6 +496,13 @@ export interface OmeggaLike
 
   /** game CL version*/
   version: number;
+
+  /**
+   * version-resolved Brickadia console command names, nested by namespace.
+   * e.g. `Omegga.Console.Bricks.Clear` resolves to the command string for the
+   * running game version ("Bricks.Clear" or "br.Bricks.Clear")
+   */
+  Console: ConsoleCommands;
 
   /** verbose logging is enabled*/
   verbose: boolean;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,7 @@ import {
 } from '@brickadia/types';
 import { ConsoleCommands } from '@omegga/commands';
 import {
+  IGamemode,
   ILogMinigame,
   IMinigameList,
   IPlayerPositions,
@@ -437,14 +438,24 @@ export interface StaticPlayer {
 export interface InjectedCommands {
   /** Get server status */
   getServerStatus(this: OmeggaLike): Promise<IServerStatus | null>;
-  /** Get a list of minigames and their indices */
+  /**
+   * Get a list of minigames and their indices
+   * @deprecated minigames were replaced by a single gamemode (~CL14000); on
+   * modern servers this returns at most one entry with an empty `owner`.
+   * Prefer {@link InjectedCommands.getGamemode}.
+   */
   listMinigames(this: OmeggaLike): Promise<IMinigameList>;
   // /** Get all pawn data */
   // getAllPawnData(this: OmeggaLike, fields: PawnDataField[]): void;
   /** Get all player positions and pawns */
   getAllPlayerPositions(this: OmeggaLike): Promise<IPlayerPositions>;
-  /** Get minigames and members */
+  /** Get minigames and members (one entry per gamemode on modern servers) */
   getMinigames(this: OmeggaLike): Promise<ILogMinigame[]>;
+  /**
+   * Get the single gamemode and its teams/players (modern servers, >=CL14000).
+   * Returns null on older servers (use {@link InjectedCommands.getMinigames}).
+   */
+  getGamemode(this: OmeggaLike): Promise<IGamemode | null>;
 }
 
 export interface MockEventEmitter {

--- a/src/updater/steam.ts
+++ b/src/updater/steam.ts
@@ -98,9 +98,15 @@ function handleSteamError(err: unknown) {
 export async function steamcmdDownloadGame({
   steambeta,
   steambetaPassword,
+  retries = 3,
+  retryDelayMs = 5000,
 }: {
   steambeta?: string;
   steambetaPassword?: string;
+  /** number of attempts before giving up (steamcmd resumes partial downloads) */
+  retries?: number;
+  /** delay between retry attempts */
+  retryDelayMs?: number;
 } = {}) {
   const hasCredentials = !!process.env.STEAM_USERNAME;
   const steamLogin = hasCredentials
@@ -128,40 +134,62 @@ export async function steamcmdDownloadGame({
 
   const cmd = `${STEAMCMD_PATH} ${args.join(' ')}`;
 
-  try {
-    execSync(cmd, { stdio: 'inherit' });
-  } catch (err) {
-    if (
-      hasCredentials &&
-      err instanceof Error &&
-      'status' in err &&
-      (err as NodeJS.ErrnoException & { status: number }).status === 5
-    ) {
-      Logger.warnp(
-        'Steam login failed. This may require Steam Guard authentication.',
-      );
-      Logger.warnp('Attempting interactive login...');
+  // steamcmd resumes partial downloads, and late-stage failures (e.g. "state is
+  // 0x406 after update job") are frequently transient, so retry before giving up.
+  const attempts = Math.max(1, retries);
+  let triedInteractiveLogin = false;
 
-      if (await steamcmdInteractiveLogin()) {
-        Logger.logp('Login successful. Retrying download...');
-        try {
-          execSync(cmd, { stdio: 'inherit' });
-          return;
-        } catch (retryErr) {
-          handleSteamError(retryErr);
-          throw retryErr;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      execSync(cmd, { stdio: 'inherit' });
+      return;
+    } catch (err) {
+      // Steam Guard interactive re-auth on status 5, attempted at most once.
+      if (
+        !triedInteractiveLogin &&
+        hasCredentials &&
+        err instanceof Error &&
+        'status' in err &&
+        (err as NodeJS.ErrnoException & { status: number }).status === 5
+      ) {
+        triedInteractiveLogin = true;
+        Logger.warnp(
+          'Steam login failed. This may require Steam Guard authentication.',
+        );
+        Logger.warnp('Attempting interactive login...');
+
+        if (await steamcmdInteractiveLogin()) {
+          Logger.logp('Login successful. Retrying download...');
+          try {
+            execSync(cmd, { stdio: 'inherit' });
+            return;
+          } catch (retryErr) {
+            handleSteamError(retryErr);
+            err = retryErr;
+          }
+        } else {
+          Logger.errorp(
+            'Interactive login failed. Run',
+            'omegga steamlogin'.yellow,
+            'to authenticate manually.',
+          );
         }
       }
 
-      Logger.errorp(
-        'Interactive login failed. Run',
-        'omegga steamlogin'.yellow,
-        'to authenticate manually.',
-      );
-    }
+      handleSteamError(err);
 
-    handleSteamError(err);
-    throw err;
+      if (attempt < attempts) {
+        Logger.warnp(
+          `Steam download attempt ${attempt}/${attempts} failed; retrying in ${Math.round(
+            retryDelayMs / 1000,
+          )}s...`,
+        );
+        await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+        continue;
+      }
+
+      throw err;
+    }
   }
 }
 

--- a/src/webserver/backend/metrics.ts
+++ b/src/webserver/backend/metrics.ts
@@ -198,6 +198,7 @@ export default function (server: Webserver) {
       try {
         await steamcmdDownloadGame({
           steambeta: omegga.config.server?.steambeta,
+          steambetaPassword: omegga.config.server?.steambetaPassword,
         });
       } catch (e) {
         error('An error occurred while downloading the update:', e);

--- a/src/webserver/backend/router/player.ts
+++ b/src/webserver/backend/router/player.ts
@@ -182,7 +182,9 @@ export const playerRouter = router({
           omegga.getNameCache()?.savedPlayerNames?.[id].yellow ??
             'with id ' + id.yellow,
         );
-        omegga.writeln(`Chat.Command /Ban "${id}" ${duration} "${reason}"`);
+        omegga.writeln(
+          `${omegga.Console.Chat.Command} /Ban "${id}" ${duration} "${reason}"`,
+        );
         const ban = await waitForEvent(database, 'update.bans', () => {
           const banList = (omegga.getBanList() || { banList: {} }).banList;
           if (!banList[id]) return false;
@@ -216,7 +218,9 @@ export const playerRouter = router({
         const player = omegga.players.find(p => p.id === id);
         if (!player) return false;
         ctx.log('Kicking player', player.name.yellow);
-        omegga.writeln(`Chat.Command /Kick "${id}" "${reason}"`);
+        omegga.writeln(
+          `${omegga.Console.Chat.Command} /Kick "${id}" "${reason}"`,
+        );
         const ok = await waitForEvent(
           omegga,
           'leave',
@@ -246,7 +250,7 @@ export const playerRouter = router({
           omegga.getNameCache()?.savedPlayerNames?.[id].yellow ??
             'with id ' + id.yellow,
         );
-        omegga.writeln(`Chat.Command /Unban "${id}"`);
+        omegga.writeln(`${omegga.Console.Chat.Command} /Unban "${id}"`);
         const ok = await waitForEvent(database, 'update.bans', () => {
           const banList = (omegga.getBanList() || { banList: {} }).banList;
           return (
@@ -267,7 +271,7 @@ export const playerRouter = router({
           omegga.getNameCache()?.savedPlayerNames?.[id]?.yellow ??
             'with id ' + id.yellow,
         );
-        omegga.writeln(`Bricks.Clear "${id}"`);
+        omegga.writeln(`${omegga.Console.Bricks.Clear} "${id}"`);
         return true;
       }),
 


### PR DESCRIPTION

## 1.8.0

Huge breaking changes on in console commands for EA3... 

They all got prefixed with BR.* so `Chat.Command` is now `BR.Chat.Command`. Luckily, Omegga will automatically use the new names so your plugins should keep working!

- Plugins: Add fetch/crypto/atob/etc builtins to safe plugins
- Plugins: Automatically use new console command names when old ones are attempted to write to console
- Add auto retry to steamcmd updater
- Start tracking console commands by name in `Omegga.Console....` like `Omegga.Console.Server.Players.GiveItem`
- Deprecate minigame functions for EA3, add a getGamemode function for EA3