### PR TITLE
1.8.1 - add prefab console command helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Future features go here
 
+## 1.8.1 - 2026-07-03
+
+Prefab support for EA3, replacing the removed `.brs` bricks commands.
+
+- Plugins: Add prefab methods (`loadPrefab`, `savePrefab`, `savePrefabAsync`, `givePrefabToPlayer`, `loadPrefabOnPlayer`, `getPrefabs`)
+- Plugins: `clearRegion`/`clearAllBricks` route to the new world clear commands on EA3 and can optionally clear entities
+- Plugins: Deprecate the `.brs` bricks methods removed by the game (`saveBricks`, `loadBricks`, `getSaveData`, `loadBricksOnPlayer`, etc.) - they warn and no-op
+- Commands: Warn when a plugin writes a console command the running game version has removed
+
 ## 1.8.0 - 2026-06-27
 
 Huge breaking changes on in console commands for EA3...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omegga",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omegga",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "ISC",
       "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omegga",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Brickadia server installer, updater, manager, wrapper, configurator, and automator",
   "engines": {
     "node": ">=23.0.0"

--- a/src/omegga/commands.test.ts
+++ b/src/omegga/commands.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Logger from '@/logger';
+import {
+  EA2_VERSION,
+  migrateConsoleCommand,
+  PREFAB_VERSION,
+  resolveConsoleCommands,
+} from './commands';
+
+const RENAME_VERSION = 14349;
+
+describe('resolveConsoleCommands', () => {
+  it('resolves legacy names before the br. rename', () => {
+    const cmds = resolveConsoleCommands(14000);
+    expect(cmds.Bricks.Clear).toBe('Bricks.Clear');
+    expect(cmds.Chat.Broadcast).toBe('Chat.Broadcast');
+  });
+
+  it('resolves br. prefixed names after the rename', () => {
+    const cmds = resolveConsoleCommands(RENAME_VERSION);
+    expect(cmds.Bricks.Clear).toBe('br.Bricks.Clear');
+    expect(cmds.Chat.Broadcast).toBe('br.Chat.Broadcast');
+  });
+
+  it('exposes the prefab and world clear commands', () => {
+    const cmds = resolveConsoleCommands(PREFAB_VERSION);
+    expect(cmds.Prefab.Load).toBe('br.Prefab.Load');
+    expect(cmds.Prefab.SaveRegion).toBe('br.Prefab.SaveRegion');
+    expect(cmds.Prefab.GiveToPlayer).toBe('br.Prefab.GiveToPlayer');
+    expect(cmds.World.ClearRegion).toBe('BR.World.ClearRegion');
+    expect(cmds.World.ClearAll).toBe('BR.World.ClearAll');
+  });
+
+  it('unknown version resolves to the newest name', () => {
+    const cmds = resolveConsoleCommands(-1);
+    expect(cmds.Bricks.Clear).toBe('br.Bricks.Clear');
+  });
+});
+
+describe('migrateConsoleCommand', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('rewrites a stale command name to the running version name', () => {
+    expect(migrateConsoleCommand('Bricks.Clear uuid 1', RENAME_VERSION)).toBe(
+      'br.Bricks.Clear uuid 1',
+    );
+  });
+
+  it('leaves already-correct and unknown commands untouched', () => {
+    expect(migrateConsoleCommand('br.Bricks.Clear uuid', RENAME_VERSION)).toBe(
+      'br.Bricks.Clear uuid',
+    );
+    expect(migrateConsoleCommand('SomePluginCommand foo', RENAME_VERSION)).toBe(
+      'SomePluginCommand foo',
+    );
+  });
+
+  it('warns once when a removed command is invoked on a newer server', () => {
+    const warn = vi.spyOn(Logger, 'warnp').mockImplementation(() => undefined);
+    // unique command so the module-level dedupe set doesn't hide the warning
+    migrateConsoleCommand('br.Bricks.Save "a"', PREFAB_VERSION);
+    migrateConsoleCommand('br.Bricks.Save "b"', PREFAB_VERSION);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/removed in Brickadia/i);
+  });
+
+  it('does not warn about removed commands on older servers', () => {
+    const warn = vi.spyOn(Logger, 'warnp').mockImplementation(() => undefined);
+    migrateConsoleCommand('br.Bricks.SaveRegion "a" 0 0 0 1 1 1', 14400);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns for LoadTemplate removed at EA2 but not on pre-EA2 servers', () => {
+    const warn = vi.spyOn(Logger, 'warnp').mockImplementation(() => undefined);
+    migrateConsoleCommand('Bricks.LoadTemplate "a" 0 0 0', EA2_VERSION - 1);
+    expect(warn).not.toHaveBeenCalled();
+    migrateConsoleCommand('Bricks.LoadTemplate "a" 0 0 0', PREFAB_VERSION);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/omegga/commands.ts
+++ b/src/omegga/commands.ts
@@ -1,3 +1,5 @@
+import Logger from '@/logger';
+
 // AUTO-GENERATED command name table. Maps each Brickadia console command to
 // its name across game versions so plugins/omegga can address commands without
 // hardcoding a name that changes between releases.
@@ -6,6 +8,9 @@
 // handful were restructured). Before that, the legacy names were used.
 // Minigames were deprecated at CL 14000 and replaced by GameMode commands;
 // the legacy Minigames commands still resolve but are no-ops on newer servers.
+// At CL 14626 the .brs bricks commands (Bricks.Save/Load/Clear*, World.LoadAdditive)
+// were removed in favor of the prefab/world commands; invoking a removed command
+// logs a warning ({@link migrateConsoleCommand}).
 //
 // Resolve the version-correct name with `omegga.Console`, e.g.
 // `omegga.Console.Bricks.Clear` -> "Bricks.Clear" or "br.Bricks.Clear".
@@ -16,8 +21,24 @@
 /** CL version at which console commands gained the `br.` prefix. */
 const RENAME_VERSION = 14349;
 
+/**
+ * CL version at which `Bricks.LoadTemplate` was removed (~EA2). Earliest EA2
+ * build observed is CL12960; the command was gone by then.
+ */
+export const EA2_VERSION = 12960;
+
+/**
+ * CL version (~EA3) at which the legacy .brs bricks console commands were
+ * removed in favor of prefab (`br.Prefab.*`) and world (`br.World.Clear*`)
+ * commands.
+ */
+export const PREFAB_VERSION = 14626;
+
 /** A console command whose name may differ across game versions. */
 export class ConsoleCommand {
+  /** CL version at which the game removed this command, if it was ever removed. */
+  removedAt?: number;
+
   /** @param versions [sinceVersion, name] pairs in ascending version order */
   constructor(private readonly versions: readonly [number, string][]) {}
 
@@ -30,6 +51,21 @@ export class ConsoleCommand {
     for (const [since, candidate] of this.versions)
       if (version >= since) name = candidate;
     return name;
+  }
+
+  /** Mark this command as removed from the game at `version` (fluent). */
+  removedIn(version: number): this {
+    this.removedAt = version;
+    return this;
+  }
+
+  /**
+   * Whether this command no longer exists at the given game version. An unknown
+   * version (server not started / not detected yet, `<= 0`) is treated as still
+   * present so we never warn on commands sent before the version is known.
+   */
+  isRemovedAt(version: number): boolean {
+    return this.removedAt != null && version > 0 && version >= this.removedAt;
   }
 
   /** every name this command has gone by, across versions */
@@ -58,8 +94,13 @@ export const COMMAND_TABLE = {
   Bricks: {
     ActuallyReduce: c('Bricks.ActuallyReduce', 'br.Bricks.ActuallyReduce'),
     Clear: c('Bricks.Clear', 'br.Bricks.Clear'),
-    ClearAll: c('Bricks.ClearAll', 'br.Bricks.ClearAll'),
-    ClearRegion: c('Bricks.ClearRegion', 'br.Bricks.ClearRegion'),
+    // removed at PREFAB_VERSION -> replaced by World.ClearAll / World.ClearRegion
+    ClearAll: c('Bricks.ClearAll', 'br.Bricks.ClearAll').removedIn(
+      PREFAB_VERSION,
+    ),
+    ClearRegion: c('Bricks.ClearRegion', 'br.Bricks.ClearRegion').removedIn(
+      PREFAB_VERSION,
+    ),
     Cluster: {
       EnableMergingDynamicGrids: c(
         'Bricks.Cluster.EnableMergingDynamicGrids',
@@ -178,8 +219,10 @@ export const COMMAND_TABLE = {
       'br.Bricks.GenerateMathTables',
     ),
     GetOctreeStats: c('Bricks.GetOctreeStats', 'br.Bricks.GetOctreeStats'),
-    Load: c('Bricks.Load', 'br.Bricks.Load'),
-    LoadTemplate: c('Bricks.LoadTemplate'),
+    // removed at PREFAB_VERSION -> replaced by Prefab.Load
+    Load: c('Bricks.Load', 'br.Bricks.Load').removedIn(PREFAB_VERSION),
+    // removed ~EA2 -> replaced by Prefab.GiveToPlayer (loadPrefabOnPlayer)
+    LoadTemplate: c('Bricks.LoadTemplate').removedIn(EA2_VERSION),
     LODScreenSizeScale: c(
       'Bricks.LODScreenSizeScale',
       'br.Bricks.LODScreenSizeScale',
@@ -217,7 +260,8 @@ export const COMMAND_TABLE = {
     ),
     RebuildClusters: c('Bricks.RebuildClusters', 'br.Bricks.RebuildClusters'),
     RebuildMeshes: c('Bricks.RebuildMeshes', 'br.Bricks.RebuildMeshes'),
-    Save: c('Bricks.Save', 'br.Bricks.Save'),
+    // removed at PREFAB_VERSION -> replaced by Prefab.SaveRegion
+    Save: c('Bricks.Save', 'br.Bricks.Save').removedIn(PREFAB_VERSION),
     SaveFileCompressionLevel: c(
       'Bricks.SaveFileCompressionLevel',
       'br.Bricks.SaveFileCompressionLevel',
@@ -246,7 +290,10 @@ export const COMMAND_TABLE = {
       'Bricks.SaveFileReadSizeLimit',
       'br.Bricks.SaveFileReadSizeLimit',
     ),
-    SaveRegion: c('Bricks.SaveRegion', 'br.Bricks.SaveRegion'),
+    // removed at PREFAB_VERSION -> replaced by Prefab.SaveRegion
+    SaveRegion: c('Bricks.SaveRegion', 'br.Bricks.SaveRegion').removedIn(
+      PREFAB_VERSION,
+    ),
     ValidateMathTables: c(
       'Bricks.ValidateMathTables',
       'br.Bricks.ValidateMathTables',
@@ -442,6 +489,12 @@ export const COMMAND_TABLE = {
   PlayerParts: {
     UseFastRender: c('br.PlayerParts.UseFastRender'),
   },
+  // prefab commands added at PREFAB_VERSION (replace the removed .brs commands)
+  Prefab: {
+    GiveToPlayer: c('br.Prefab.GiveToPlayer'),
+    Load: c('br.Prefab.Load'),
+    SaveRegion: c('br.Prefab.SaveRegion'),
+  },
   Resizer: {
     LogTests: c('br.Resizer.LogTests'),
   },
@@ -591,10 +644,14 @@ export const COMMAND_TABLE = {
     EnableWires: c('BR.WireRenderer.EnableWires'),
   },
   World: {
+    // added at PREFAB_VERSION (replace the removed Bricks.ClearAll/ClearRegion)
+    ClearAll: c('BR.World.ClearAll'),
+    ClearRegion: c('BR.World.ClearRegion'),
     CreateEmpty: c('BR.World.CreateEmpty'),
     ListRevisions: c('BR.World.ListRevisions'),
     Load: c('BR.World.Load'),
-    LoadAdditive: c('BR.World.LoadAdditive'),
+    // removed at PREFAB_VERSION -> use Prefab.Load
+    LoadAdditive: c('BR.World.LoadAdditive').removedIn(PREFAB_VERSION),
     LoadRevision: c('BR.World.LoadRevision'),
     Save: c('BR.World.Save'),
     SaveAs: c('BR.World.SaveAs'),
@@ -641,6 +698,9 @@ export const resolveConsoleCommands = (version: number): ConsoleCommands =>
 // -> the command. First write wins so canonical commands keep priority over
 // the deprecated aliases injected later in the table.
 const COMMAND_LOOKUP = new Map<string, ConsoleCommand>();
+
+// removed-command names (lowercased) we've already warned about, to avoid spam
+const warnedRemovedCommands = new Set<string>();
 const indexTree = (tree: CommandTree): void => {
   for (const key in tree) {
     const value = tree[key];
@@ -671,6 +731,20 @@ export const migrateConsoleCommand = (
   const head = space === -1 ? line : line.slice(0, space);
   const command = COMMAND_LOOKUP.get(head.toLowerCase());
   if (!command) return line;
+
+  // warn (once per command) when a plugin invokes a command the running game
+  // version has removed - it will have no effect
+  if (
+    command.isRemovedAt(version) &&
+    !warnedRemovedCommands.has(head.toLowerCase())
+  ) {
+    warnedRemovedCommands.add(head.toLowerCase());
+    Logger.warnp(
+      `Console command "${head}" was removed in Brickadia CL${command.removedAt} ` +
+        `and will have no effect. Update the plugin using it to the prefab/world equivalent.`,
+    );
+  }
+
   const resolved = command.resolve(version);
   // already a valid name for this version (console names are case-insensitive)
   if (resolved.toLowerCase() === head.toLowerCase()) return line;

--- a/src/omegga/plugin/plugin_jsonrpc_stdio.ts
+++ b/src/omegga/plugin/plugin_jsonrpc_stdio.ts
@@ -475,6 +475,80 @@ export default class RpcPlugin extends Plugin {
     rpc.addMethod('getSavePath', name =>
       this.omegga.getSavePath(name as unknown as string),
     );
+    rpc.addMethod('getPrefabs', () => this.omegga.getPrefabs());
+    rpc.addMethod(
+      'loadPrefab',
+      ({
+        path,
+        ...options
+      }: {
+        path: string;
+        offX?: number;
+        offY?: number;
+        offZ?: number;
+        atOriginalPosition?: boolean;
+        orientation?: number;
+        rootEntityPersistentIndex?: number;
+        mirrorAxes?: number;
+        overrideUserId?: string;
+      }) => this.omegga.loadPrefab(path, options),
+    );
+    rpc.addMethod(
+      'savePrefab',
+      ({
+        path,
+        ...options
+      }: {
+        path: string;
+        region?: {
+          center: [number, number, number];
+          extent: [number, number, number];
+        };
+        entities?: boolean;
+        rootEntityPersistentIndex?: number;
+        userId?: string;
+      }) => this.omegga.savePrefab(path, options),
+    );
+    rpc.addMethod(
+      'savePrefabAsync',
+      ({
+        path,
+        ...options
+      }: {
+        path: string;
+        region?: {
+          center: [number, number, number];
+          extent: [number, number, number];
+        };
+        entities?: boolean;
+        rootEntityPersistentIndex?: number;
+        userId?: string;
+      }) => this.omegga.savePrefabAsync(path, options),
+    );
+    rpc.addMethod(
+      'givePrefabToPlayer',
+      ({
+        path,
+        player,
+        preserveOwnership = false,
+      }: {
+        path: string;
+        player: string;
+        preserveOwnership?: boolean;
+      }) => this.omegga.givePrefabToPlayer(path, player, { preserveOwnership }),
+    );
+    rpc.addMethod(
+      'loadPrefabOnPlayer',
+      ({
+        path,
+        player,
+        preserveOwnership = false,
+      }: {
+        path: string;
+        player: string;
+        preserveOwnership?: boolean;
+      }) => this.omegga.loadPrefabOnPlayer(path, player, { preserveOwnership }),
+    );
     rpc.addMethod(
       'clearBricks',
       ({ target, quiet = false }: { target: string; quiet?: boolean }) =>

--- a/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
+++ b/src/omegga/plugin/plugin_node_safe/proxyOmegga.ts
@@ -69,6 +69,12 @@ const STEAL_PROTOTYPES: Record<keyof Required<OmeggaCore>, true> = {
   getSaves: true,
   getWorldPath: true,
   getWorlds: true,
+  getPrefabs: true,
+  loadPrefab: true,
+  loadPrefabOnPlayer: true,
+  savePrefab: true,
+  savePrefabAsync: true,
+  givePrefabToPlayer: true,
   getWorldRevisions: true,
   loadWorld: true,
   loadWorldRevision: true,
@@ -329,13 +335,19 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
       center: [number, number, number];
       extent: [number, number, number];
     },
-    options: {
-      target: string | OmeggaPlayer;
+    options?: {
+      target?: string | OmeggaPlayer;
+      bricks?: boolean;
+      entities?: boolean;
     },
   ): void {
     throw badBorrow('clearRegion');
   }
-  clearAllBricks(quiet?: boolean): void {
+  clearAllBricks(
+    options?:
+      | boolean
+      | { quiet?: boolean; bricks?: boolean; entities?: boolean },
+  ): void {
     throw badBorrow('clearAllBricks');
   }
   saveBricks(saveName: string, region?: {}): void {
@@ -362,6 +374,66 @@ export class ProxyOmegga extends EventEmitter implements OmeggaLike {
   }
   getWorlds(): string[] {
     throw badBorrow('getWorlds');
+  }
+  getPrefabs(): string[] {
+    throw badBorrow('getPrefabs');
+  }
+  loadPrefab(
+    path: string,
+    options?: {
+      offX?: number;
+      offY?: number;
+      offZ?: number;
+      atOriginalPosition?: boolean;
+      orientation?: number;
+      rootEntityPersistentIndex?: number;
+      mirrorAxes?: number;
+      overrideUserId?: string;
+    },
+  ): void {
+    throw badBorrow('loadPrefab');
+  }
+  loadPrefabOnPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    options?: { preserveOwnership?: boolean },
+  ): void {
+    throw badBorrow('loadPrefabOnPlayer');
+  }
+  savePrefab(
+    path: string,
+    options?: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    },
+  ): void {
+    throw badBorrow('savePrefab');
+  }
+  savePrefabAsync(
+    path: string,
+    options?: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    },
+  ): Promise<string | null> {
+    throw badBorrow('savePrefabAsync');
+  }
+  givePrefabToPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    options?: { preserveOwnership?: boolean },
+  ): void {
+    throw badBorrow('givePrefabToPlayer');
   }
   getSavePath(saveName: string): string {
     throw badBorrow('getSavePath');

--- a/src/omegga/server.ts
+++ b/src/omegga/server.ts
@@ -26,7 +26,12 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'path';
 import { AutoRestartConfig } from '..';
 import commandInjector from './commandInjector';
-import { ConsoleCommands, resolveConsoleCommands } from './commands';
+import {
+  ConsoleCommands,
+  EA2_VERSION,
+  PREFAB_VERSION,
+  resolveConsoleCommands,
+} from './commands';
 import MATCHERS from './matchers';
 import Player from './player';
 import { PluginLoader } from './plugin';
@@ -43,6 +48,10 @@ import OmeggaWrapper from './wrapper';
 const MISSING_CMD =
   '"Command not found. Type <color=\\"ffff00\\">/help</> for a list of commands or <color=\\"ffff00\\">/plugins</> for plugin information."';
 
+// Prefab.SaveRegion requires a region; when saving the whole world we pass a
+// maximal extent centered on the origin to capture everything.
+const WHOLE_WORLD_EXTENT = 1_000_000_000;
+
 // TODO: safe broadcast parsing
 
 export default class Omegga extends OmeggaWrapper implements OmeggaLike {
@@ -58,6 +67,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   verbose: boolean;
   savePath: string;
   worldPath: string;
+  prefabPath: string;
   presetPath: string;
   configPath: string;
   options: IOmeggaOptions;
@@ -135,6 +145,7 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     // path to save files
     this.savePath = join(this.path, DATA_PATH, savedDir, 'Builds');
     this.worldPath = join(this.path, DATA_PATH, savedDir, 'Worlds');
+    this.prefabPath = join(this.path, DATA_PATH, savedDir, 'Prefabs');
 
     this.presetPath = join(this.path, DATA_PATH, savedDir, 'Presets');
 
@@ -660,6 +671,38 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       : [];
   }
 
+  /**
+   * Whether the running game version has removed the legacy .brs bricks console
+   * commands (Bricks.Save/Load/ClearAll/ClearRegion, World.LoadAdditive) in
+   * favor of the prefab (`br.Prefab.*`) and world (`br.World.Clear*`) commands.
+   * Removed at Brickadia CL{@link PREFAB_VERSION}.
+   */
+  #brsRemoved(): boolean {
+    return this.version > 0 && this.version >= PREFAB_VERSION;
+  }
+
+  /**
+   * Warn that a method backed by a removed console command is a no-op on the
+   * running game version, and return whether the caller should bail.
+   * @param method the omegga method being called (for the message)
+   * @param since CL version the underlying command was removed at
+   * @param release human release name for that version (e.g. `EA2`, `EA3`)
+   * @param replacement suggested replacement method/API
+   */
+  #warnRemoved(
+    method: string,
+    since: number,
+    release: string,
+    replacement: string,
+  ): boolean {
+    if (!(this.version > 0 && this.version >= since)) return false;
+    Logger.warnp(
+      `omegga.${method}() uses a console command removed in Brickadia ` +
+        `${release}. This call has no effect - use ${replacement} instead.`,
+    );
+    return true;
+  }
+
   clearBricks(target: string | { id: string }, quiet = false) {
     // target is a player object, just use that id
     if (typeof target === 'object' && target.id) target = target.id;
@@ -680,29 +723,68 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       center: [number, number, number];
       extent: [number, number, number];
     },
-    options?: { target: string | OmeggaPlayer },
+    options?: {
+      target?: string | OmeggaPlayer;
+      /** clear bricks in the region (default true) */
+      bricks?: boolean;
+      /** also clear entities in the region (default false, EA3 only) */
+      entities?: boolean;
+    },
   ) {
+    // resolve the optional owner filter (player object, uuid, or name) to a uuid
     let target = '';
-
-    // target is a player object, just use that id
-    if (options && typeof options.target === 'object')
-      target = ' ' + options.target.id;
-    // if the target isn't a uuid already, find the player by name or controller and use that uuid
-
-    if (typeof target === 'string' && !uuid.match(target)) {
-      // only set the target if the player exists
-      const player = this.getPlayer(target);
-      if (player) target = ' ' + player.id;
+    const rawTarget = options?.target;
+    if (rawTarget) {
+      if (typeof rawTarget === 'object') target = rawTarget.id;
+      else if (uuid.match(rawTarget)) target = rawTarget;
+      else target = this.getPlayer(rawTarget)?.id ?? '';
     }
 
+    const center = region.center.join(' ');
+    const extent = region.extent.join(' ');
+
+    if (this.#brsRemoved()) {
+      // br.World.ClearRegion <Center> <Extent> [ClearBricks] [ClearEntities] [FilterUserId]
+      const bricks = (options?.bricks ?? true) ? 1 : 0;
+      const entities = (options?.entities ?? false) ? 1 : 0;
+      this.writeln(
+        `${this.Console.World.ClearRegion} ${center} ${extent} ${bricks} ${entities}${
+          target ? ' ' + target : ''
+        }`,
+      );
+      return;
+    }
+
+    // legacy .brs region clear (bricks only)
     this.writeln(
-      `${this.Console.Bricks.ClearRegion} ${region.center.join(' ')} ${region.extent.join(
-        ' ',
-      )}${target}`,
+      `${this.Console.Bricks.ClearRegion} ${center} ${extent}${
+        target ? ' ' + target : ''
+      }`,
     );
   }
 
-  clearAllBricks(quiet = false) {
+  clearAllBricks(
+    options:
+      | boolean
+      | { quiet?: boolean; bricks?: boolean; entities?: boolean } = {},
+  ) {
+    // backwards compat: a bare boolean is the legacy `quiet` argument
+    const {
+      quiet = false,
+      bricks = true,
+      entities = false,
+    } = typeof options === 'boolean' ? { quiet: options } : options;
+
+    if (this.#brsRemoved()) {
+      // br.World.ClearAll [ClearBricks] [ClearEntities] [Silent]
+      this.writeln(
+        `${this.Console.World.ClearAll} ${bricks ? 1 : 0} ${
+          entities ? 1 : 0
+        } ${quiet ? 1 : 0}`,
+      );
+      return;
+    }
+    // legacy Bricks.ClearAll only ever cleared bricks
     this.writeln(`${this.Console.Bricks.ClearAll} ${quiet ? 1 : ''}`);
   }
 
@@ -713,6 +795,8 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       extent: [number, number, number];
     },
   ) {
+    if (this.#warnRemoved('saveBricks', PREFAB_VERSION, 'EA3', 'savePrefab'))
+      return;
     if (!saveName) return;
 
     // add quotes around the filename if it doesn't have them (backwards compat w/ plugins)
@@ -735,6 +819,15 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       extent: [number, number, number];
     },
   ): Promise<void> {
+    if (
+      this.#warnRemoved(
+        'saveBricksAsync',
+        PREFAB_VERSION,
+        'EA3',
+        'savePrefabAsync',
+      )
+    )
+      return;
     if (!saveName) return;
 
     let saveNameClean = saveName;
@@ -774,6 +867,8 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       correctCustom = false,
     } = {},
   ) {
+    if (this.#warnRemoved('loadBricks', PREFAB_VERSION, 'EA3', 'loadPrefab'))
+      return;
     // add quotes around the filename if it doesn't have them (backwards compat w/ plugins)
     if (!(saveName.startsWith('"') && saveName.endsWith('"')))
       saveName = `"${saveName}"`;
@@ -796,6 +891,15 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       correctCustom = false,
     } = {},
   ) {
+    if (
+      this.#warnRemoved(
+        'loadBricksOnPlayer',
+        EA2_VERSION,
+        'EA2',
+        'loadPrefabOnPlayer',
+      )
+    )
+      return;
     player = typeof player === 'string' ? this.getPlayer(player) : player;
     if (!player) return;
 
@@ -819,6 +923,12 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
   getWorlds(): string[] {
     return existsSync(this.worldPath)
       ? glob.sync(this.worldPath + '/**/*.brdb')
+      : [];
+  }
+
+  getPrefabs(): string[] {
+    return existsSync(this.prefabPath)
+      ? glob.sync(this.prefabPath + '/**/*.brz')
       : [];
   }
 
@@ -1067,6 +1177,8 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       correctCustom = false,
     } = {},
   ) {
+    if (this.#warnRemoved('loadSaveData', PREFAB_VERSION, 'EA3', 'loadPrefab'))
+      return;
     const saveFile =
       this._tempSavePrefix + Date.now() + '_' + this._tempCounter.save++;
     // write savedata to file
@@ -1104,6 +1216,15 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
       correctCustom = false,
     } = {},
   ) {
+    if (
+      this.#warnRemoved(
+        'loadSaveDataOnPlayer',
+        EA2_VERSION,
+        'EA2',
+        'loadPrefabOnPlayer',
+      )
+    )
+      return;
     player = typeof player === 'string' ? this.getPlayer(player) : player;
     if (!player) return;
 
@@ -1137,6 +1258,10 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     center: [number, number, number];
     extent: [number, number, number];
   }) {
+    if (
+      this.#warnRemoved('getSaveData', PREFAB_VERSION, 'EA3', 'the prefab API')
+    )
+      return undefined;
     const saveFile =
       this._tempSavePrefix + Date.now() + '_' + this._tempCounter.save++;
 
@@ -1156,6 +1281,156 @@ export default class Omegga extends OmeggaWrapper implements OmeggaLike {
     }
 
     return undefined;
+  }
+
+  /**
+   * Load a prefab into the world (EA3). `path` is a bundle
+   * path ref such as `Prefabs/Uploads/<hash>.brz`.
+   * br.Prefab.Load <Path> [Offset X Y Z] [At Original Position] [Orientation]
+   *   [Root Entity Persistent Index] [Mirror Axes] [Override User Id]
+   */
+  loadPrefab(
+    path: string,
+    {
+      offX = 0,
+      offY = 0,
+      offZ = 0,
+      atOriginalPosition = false,
+      orientation = 0,
+      rootEntityPersistentIndex = -1,
+      mirrorAxes = 0,
+      overrideUserId = '',
+    }: {
+      offX?: number;
+      offY?: number;
+      offZ?: number;
+      atOriginalPosition?: boolean;
+      orientation?: number;
+      rootEntityPersistentIndex?: number;
+      /** bitmask: X=1 Y=2 Z=4 (e.g. 3 mirrors X and Y) */
+      mirrorAxes?: number;
+      overrideUserId?: string;
+    } = {},
+  ) {
+    if (!path) return;
+    this.writeln(
+      `${this.Console.Prefab.Load} "${path}" ${offX} ${offY} ${offZ} ${
+        atOriginalPosition ? 1 : 0
+      } ${orientation} ${rootEntityPersistentIndex} ${mirrorAxes}${
+        overrideUserId ? ` "${overrideUserId}"` : ''
+      }`,
+    );
+  }
+
+  /**
+   * Load a prefab onto a player (EA3). Replaces the
+   * removed {@link loadBricksOnPlayer}; backed by `br.Prefab.GiveToPlayer`.
+   * @param path prefab bundle path ref
+   * @param player player name/id or player object
+   * @param options give options (preserve ownership)
+   */
+  loadPrefabOnPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    { preserveOwnership = false }: { preserveOwnership?: boolean } = {},
+  ) {
+    this.givePrefabToPlayer(path, player, { preserveOwnership });
+  }
+
+  /**
+   * Save the world (or a region of it) as a prefab (EA3).
+   * `path` is the destination bundle path ref (e.g. `Prefabs/MyPrefab.brz`).
+   * br.Prefab.SaveRegion <Path> <Center X Y Z> <Extent X Y Z> [Include Entities]
+   *   [Root Entity Persistent Index] [Filter User Id]
+   * @param path destination prefab bundle path ref
+   * @param options save options; omit `region` to capture the whole world
+   */
+  savePrefab(
+    path: string,
+    {
+      region,
+      entities = true,
+      rootEntityPersistentIndex = -1,
+      userId = '',
+    }: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    } = {},
+  ) {
+    if (!path) return;
+    // the command always takes a region; with none given, capture the whole
+    // world from the origin with a maximal extent
+    const center = (region?.center ?? [0, 0, 0]).join(' ');
+    const extent = (
+      region?.extent ?? [
+        WHOLE_WORLD_EXTENT,
+        WHOLE_WORLD_EXTENT,
+        WHOLE_WORLD_EXTENT,
+      ]
+    ).join(' ');
+    this.writeln(
+      `${this.Console.Prefab.SaveRegion} "${path}" ${center} ${extent} ${
+        entities ? 1 : 0
+      } ${rootEntityPersistentIndex}${userId ? ` "${userId}"` : ''}`,
+    );
+  }
+
+  /**
+   * Save a prefab and resolve once the prefab file has been written to disk.
+   * @param path destination prefab bundle path ref
+   * @param options same options as {@link savePrefab}
+   * @returns the absolute path to the written prefab, or null on timeout
+   */
+  async savePrefabAsync(
+    path: string,
+    options?: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    },
+  ): Promise<string | null> {
+    if (!path) return null;
+    this.savePrefab(path, options);
+
+    // TODO: confirm the write via the prefab-saved log line once its exact
+    // format is nailed down; for now poll for the written file on disk.
+    const name = path.replace(/^Prefabs[\\/]/i, '').replace(/\.brz$/i, '');
+    const file = join(this.prefabPath, name + '.brz');
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      if (existsSync(file)) return file;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    return null;
+  }
+
+  /**
+   * Give a prefab to a player's inventory (EA3).
+   * br.Prefab.GiveToPlayer <Path> <Player Name or User Id> [Preserve Ownership]
+   */
+  givePrefabToPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    { preserveOwnership = false }: { preserveOwnership?: boolean } = {},
+  ) {
+    if (!path) return;
+    // the command accepts a player name or user id; prefer the resolved id
+    const target = typeof player === 'object' ? player.id : player;
+    if (!target) return;
+    this.writeln(
+      `${this.Console.Prefab.GiveToPlayer} "${path}" "${target}" ${
+        preserveOwnership ? 1 : 0
+      }`,
+    );
   }
 
   // TODO: switch this to use worlds...

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -693,7 +693,8 @@ export interface OmeggaCore {
   clearBricks(target: string | { id: string }, quiet?: boolean): void;
 
   /**
-   * Clear a region of bricks
+   * Clear a region of bricks. On EA3 this routes to `br.World.ClearRegion`
+   * and can optionally clear entities too.
    * @param region region to clear
    * @param options optional settings
    */
@@ -704,19 +705,31 @@ export interface OmeggaCore {
     },
     options?: {
       target?: string | OmeggaPlayer;
+      /** clear bricks in the region (default true) */
+      bricks?: boolean;
+      /** also clear entities in the region (default false, EA3 only) */
+      entities?: boolean;
     },
   ): void;
 
   /**
-   * Clear all bricks on the server
-   * @param quiet quietly clear bricks
+   * Clear all bricks on the server. On EA3 this routes to
+   * `br.World.ClearAll` and can optionally clear entities too. A bare boolean
+   * is accepted as the legacy `quiet` argument.
+   * @param options quiet (or `{ quiet, bricks, entities }`)
    */
-  clearAllBricks(quiet?: boolean): void;
+  clearAllBricks(
+    options?:
+      | boolean
+      | { quiet?: boolean; bricks?: boolean; entities?: boolean },
+  ): void;
 
   /**
    * Save bricks under a filename
    * @param saveName save file name
    * @param region region of bricks to save
+   * @deprecated removed in Brickadia EA3 (no-op on newer servers) - save a
+   * prefab with {@link savePrefabRegion} instead
    */
   saveBricks(
     saveName: string,
@@ -730,6 +743,8 @@ export interface OmeggaCore {
    * Save bricks under a filename, with a promise
    * @param saveName save file name
    * @param region region of bricks to save
+   * @deprecated removed in Brickadia EA3 (no-op on newer servers) - save a
+   * prefab with {@link savePrefabRegion} instead
    */
   saveBricksAsync(
     saveName: string,
@@ -741,6 +756,8 @@ export interface OmeggaCore {
 
   /**
    * Load bricks on the server
+   * @deprecated removed in Brickadia EA3 (no-op on newer servers) - load a
+   * prefab with {@link loadPrefab} instead
    */
   loadBricks(
     saveName: string,
@@ -756,6 +773,8 @@ export interface OmeggaCore {
 
   /**
    * Load bricks on the server into a player's clipbaord
+   * @deprecated removed in Brickadia ~EA2 (no-op on newer servers) - use
+   * {@link loadPrefabOnPlayer} instead
    */
   loadBricksOnPlayer(
     saveName: string,
@@ -847,6 +866,8 @@ export interface OmeggaCore {
   /**
    * load bricks from save data and resolve when game finishes loading
    * @param saveData BRS JS Save data
+   * @deprecated removed in Brickadia EA3 (no-op on newer servers) - use the
+   * prefab API ({@link loadPrefab}) instead
    */
   loadSaveData(
     saveData: WriteSaveObject,
@@ -864,6 +885,8 @@ export interface OmeggaCore {
    * load bricks from save data and resolve when game finishes loading
    * @param saveData BRS JS Save data
    * @param player Player name/id or player object
+   * @deprecated removed in Brickadia ~EA2 (no-op on newer servers) - use the
+   * prefab API ({@link loadPrefabOnPlayer}) instead
    */
   loadSaveDataOnPlayer(
     saveData: WriteSaveObject,
@@ -879,11 +902,101 @@ export interface OmeggaCore {
 
   /**
    * get current bricks as save data
+   * @deprecated removed in Brickadia EA3 (returns undefined on newer
+   * servers) - use the prefab API instead
    */
   getSaveData(region?: {
     center: [number, number, number];
     extent: [number, number, number];
   }): Promise<ReadSaveObject>;
+
+  /**
+   * Get all prefabs in the prefabs folder and child folders (EA3)
+   */
+  getPrefabs(): string[];
+
+  /**
+   * Load a prefab into the world (EA3). `path` is a bundle path ref such
+   * as `Prefabs/Uploads/<hash>.brz`.
+   * @param path prefab bundle path ref
+   * @param options placement options (offset, orientation, mirror axes, etc)
+   */
+  loadPrefab(
+    path: string,
+    options?: {
+      offX?: number;
+      offY?: number;
+      offZ?: number;
+      atOriginalPosition?: boolean;
+      orientation?: number;
+      rootEntityPersistentIndex?: number;
+      /** bitmask: X=1 Y=2 Z=4 (e.g. 3 mirrors X and Y) */
+      mirrorAxes?: number;
+      overrideUserId?: string;
+    },
+  ): void;
+
+  /**
+   * Save the world (or a region of it) as a prefab (EA3).
+   * @param path destination prefab bundle path ref (e.g. `Prefabs/MyPrefab.brz`)
+   * @param options save options; omit `region` to capture the whole world
+   */
+  savePrefab(
+    path: string,
+    options?: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    },
+  ): void;
+
+  /**
+   * Save a prefab and resolve once the prefab file has been written to disk
+   * (EA3).
+   * @param path destination prefab bundle path ref
+   * @param options same options as {@link savePrefab}
+   * @returns absolute path to the written prefab, or null on timeout
+   */
+  savePrefabAsync(
+    path: string,
+    options?: {
+      region?: {
+        center: [number, number, number];
+        extent: [number, number, number];
+      };
+      entities?: boolean;
+      rootEntityPersistentIndex?: number;
+      userId?: string;
+    },
+  ): Promise<string | null>;
+
+  /**
+   * Give a prefab to a player's inventory (EA3).
+   * @param path prefab bundle path ref
+   * @param player player name/id or player object
+   * @param options give options (preserve ownership)
+   */
+  givePrefabToPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    options?: { preserveOwnership?: boolean },
+  ): void;
+
+  /**
+   * Load a prefab onto a player (EA3, replaces {@link loadBricksOnPlayer}).
+   * @param path prefab bundle path ref
+   * @param player player name/id or player object
+   * @param options give options (preserve ownership)
+   */
+  loadPrefabOnPlayer(
+    path: string,
+    player: string | OmeggaPlayer,
+    options?: { preserveOwnership?: boolean },
+  ): void;
 
   /**
    * Change server map


### PR DESCRIPTION
## 1.8.1 - 2026-07-03

Prefab support for EA3, replacing the removed `.brs` bricks commands.

- Plugins: Add prefab methods (`loadPrefab`, `savePrefab`, `savePrefabAsync`, `givePrefabToPlayer`, `loadPrefabOnPlayer`, `getPrefabs`)
- Plugins: `clearRegion`/`clearAllBricks` route to the new world clear commands on EA3 and can optionally clear entities
- Plugins: Deprecate the `.brs` bricks methods removed by the game (`saveBricks`, `loadBricks`, `getSaveData`, `loadBricksOnPlayer`, etc.) - they warn and no-op
- Commands: Warn when a plugin writes a console command the running game version has removed
